### PR TITLE
Move all communications to hardware back into OpenBCI_ADS1299 

### DIFF
--- a/OpenBCI_GUI/ChannelController.pde
+++ b/OpenBCI_GUI/ChannelController.pde
@@ -100,7 +100,7 @@ class ChannelController {
 	}
 
 	public void loadDefaultChannelSettings(){
-		verbosePrint("loading default channel settings to GUI's channel controller...");
+		verbosePrint("ChannelController: loading default channel settings to GUI's channel controller...");
 		for(int i = 0; i < nchan; i++){
 			verbosePrint("chan: " + i + " ");
 			for(int j = 0; j < numSettingsPerChannel; j++){ //channel setting values
@@ -613,7 +613,7 @@ class ChannelController {
 	public void createChannelSettingButtons(){
 		//the size and space of these buttons are dependendant on the size of the screen and full ChannelController
 		
-		verbosePrint("creating channel setting buttons...");
+		verbosePrint("ChannelController: createChannelSettingButtons: creating channel setting buttons...");
 		int buttonW = 0;
 		int buttonX = 0;
 		int buttonH = 0;

--- a/OpenBCI_GUI/ChannelController.pde
+++ b/OpenBCI_GUI/ChannelController.pde
@@ -303,15 +303,15 @@ class ChannelController {
 			}
 		}
 
-		if(eegDataSource != DATASOURCE_NORMAL && eegDataSource != DATASOURCE_NORMAL_W_AUX){
+		if ((eegDataSource != DATASOURCE_NORMAL) && (eegDataSource != DATASOURCE_NORMAL_W_AUX)) {
 			fill(0,0,0,200);
 			rect(x1 + w1/3 + 1, y1, 2*(w1/3) - 3, h1 - 2);
 		}
 
 		for (int i = 0; i < nchan; i++){
-			if(drawImpedanceValues[i] == true){
+			if (drawImpedanceValues[i] == true) {
 				gui.impValuesMontage[i].draw();  //impedance values on montage plot
-	        }
+	                }
 		}
 
 		popStyle();
@@ -322,11 +322,11 @@ class ChannelController {
 		//if fullChannelController and one of the buttons (other than ON/OFF) is clicked
 
 		//if dataSource is coming from OpenBCI, allow user to interact with channel controller
-		if(eegDataSource == DATASOURCE_NORMAL || eegDataSource == DATASOURCE_NORMAL_W_AUX){
-			if(showFullController){
-				for(int i = 0; i < nchan; i++){ //When [i][j] button is clicked
-					for(int j = 1; j < numSettingsPerChannel; j++){		
-						if(channelSettingButtons[i][j].isMouseHere()){
+		if ( (eegDataSource == DATASOURCE_NORMAL) || (eegDataSource == DATASOURCE_NORMAL_W_AUX) ) {
+			if (showFullController) {
+				for (int i = 0; i < nchan; i++) { //When [i][j] button is clicked
+					for (int j = 1; j < numSettingsPerChannel; j++) {		
+						if (channelSettingButtons[i][j].isMouseHere()) {
 							//increment [i][j] channelSettingValue by, until it reaches max values per setting [j], 
 							channelSettingButtons[i][j].wasPressed = true;
 							channelSettingButtons[i][j].isActive = true;
@@ -343,7 +343,7 @@ class ChannelController {
 			}
 
 			//only allow editing of impedance if dataSource == from OpenBCI
-			if(eegDataSource == DATASOURCE_NORMAL || eegDataSource == DATASOURCE_NORMAL_W_AUX){
+			if ((eegDataSource == DATASOURCE_NORMAL) || (eegDataSource == DATASOURCE_NORMAL_W_AUX)) {
 				if(impedanceCheckButtons[i][0].isMouseHere()){
 					impedanceCheckButtons[i][0].wasPressed = true;
 					impedanceCheckButtons[i][0].isActive = true;
@@ -463,13 +463,14 @@ class ChannelController {
 
 		// initChannelWrite(_numChannel);//writeChannelSettings
 		channelSettingValues[_numChannel][0] = '1'; //update powerUp/powerDown value of 2D array
-		if(_numChannel < 8){
+		//if(_numChannel < 8){
 			verbosePrint("Command: " + command_deactivate_channel[_numChannel]);
-			openBCI.serial_openBCI.write(command_deactivate_channel[_numChannel]);
-		}else{ //if a daisy channel
-			verbosePrint("Command: " + command_deactivate_channel_daisy[_numChannel - 8]);
-			openBCI.serial_openBCI.write(command_deactivate_channel_daisy[_numChannel - 8]);
-		}
+			//openBCI.serial_openBCI.write(command_deactivate_channel[_numChannel]);
+                        openBCI.deactivateChannel(_numChannel);  //assumes numChannel counts from zero (not one)...handles regular and daisy channels
+		//}else{ //if a daisy channel
+		//	verbosePrint("Command: " + command_deactivate_channel_daisy[_numChannel - 8]);
+		//	openBCI.serial_openBCI.write(command_deactivate_channel_daisy[_numChannel - 8]);
+		//}
 	}
 
 	public void powerUpChannel(int _numChannel){
@@ -480,13 +481,14 @@ class ChannelController {
 
 		// initChannelWrite(_numChannel);//writeChannelSettings
 		channelSettingValues[_numChannel][0] = '0'; //update powerUp/powerDown value of 2D array
-		if(_numChannel < 8){
+		//if(_numChannel < 8){
 			verbosePrint("Command: " + command_activate_channel[_numChannel]);
-			openBCI.serial_openBCI.write(command_activate_channel[_numChannel]);
-		} else{ //if a daisy channel
-			verbosePrint("Command: " + command_activate_channel_daisy[_numChannel - 8]);
-			openBCI.serial_openBCI.write(command_activate_channel_daisy[_numChannel - 8]);
-		}
+			//openBCI.serial_openBCI.write(command_activate_channel[_numChannel]);
+                        openBCI.activateChannel(_numChannel);  //assumes numChannel counts from zero (not one)...handles regular and daisy channels//assumes numChannel counts from zero (not one)...handles regular and daisy channels
+		//} else{ //if a daisy channel
+		//	verbosePrint("Command: " + command_activate_channel_daisy[_numChannel - 8]);
+		//	openBCI.serial_openBCI.write(command_activate_channel_daisy[_numChannel - 8]);
+		//}
 	}
 
 	public void initChannelWrite(int _numChannel){
@@ -533,7 +535,7 @@ class ChannelController {
 	}
 
 	public void writeChannelSettings(int _numChannel){
-		if(millis() - timeOfLastChannelWrite >= 50){
+		if(millis() - timeOfLastChannelWrite >= 50){ //wait 50 milliseconds before sending next character
 			verbosePrint("---");
 			switch (channelWriteCounter){
 				case 0: //start sequence by send 'x'
@@ -546,7 +548,8 @@ class ChannelController {
 						openBCI.serial_openBCI.write((char)('0'+(_numChannel+1)));
 					}
 					if(_numChannel >= 8){
-						openBCI.serial_openBCI.write((command_activate_channel_daisy[_numChannel-8]));
+						//openBCI.serial_openBCI.write((command_activate_channel_daisy[_numChannel-8]));
+                                                openBCI.serial_openBCI.write((command_activate_channel[_numChannel])); //command_activate_channel holds non-daisy and daisy
 					}
 					break;
 				case 2: case 3: case 4: case 5: case 6: case 7:
@@ -574,10 +577,10 @@ class ChannelController {
 			//after clicking any button, write the new settings for that channel to OpenBCI
 		// verbosePrint("Writing impedance settings for channel " + _numChannel + " to OpenBCI!");
 		//write setting 1, delay 5ms.. write setting 2, delay 5ms, etc.
-		if(millis() - timeOfLastImpWrite >= 50){
+		if(millis() - timeOfLastImpWrite >= 50){ //wait 50 milliseconds before sending next character
 			verbosePrint("---");
 			switch (impWriteCounter){
-				case 0: //start sequence by send 'x'
+				case 0: //start sequence by sending 'z'
 					verbosePrint("z" + " :: " + millis());
 					openBCI.serial_openBCI.write('z');
 					break;
@@ -587,7 +590,8 @@ class ChannelController {
 						openBCI.serial_openBCI.write((char)('0'+(_numChannel+1)));
 					}
 					if(_numChannel >= 8){
-						openBCI.serial_openBCI.write((command_activate_channel_daisy[_numChannel-8]));
+						//openBCI.serial_openBCI.write((command_activate_channel_daisy[_numChannel-8]));
+                                                openBCI.serial_openBCI.write((command_activate_channel[_numChannel])); //command_activate_channel holds non-daisy and daisy values
 					}
 					break;
 				case 2: case 3: 

--- a/OpenBCI_GUI/ChannelController.pde
+++ b/OpenBCI_GUI/ChannelController.pde
@@ -465,10 +465,10 @@ class ChannelController {
 		channelSettingValues[_numChannel][0] = '1'; //update powerUp/powerDown value of 2D array
 		if(_numChannel < 8){
 			verbosePrint("Command: " + command_deactivate_channel[_numChannel]);
-			serial_openBCI.write(command_deactivate_channel[_numChannel]);
+			openBCI.serial_openBCI.write(command_deactivate_channel[_numChannel]);
 		}else{ //if a daisy channel
 			verbosePrint("Command: " + command_deactivate_channel_daisy[_numChannel - 8]);
-			serial_openBCI.write(command_deactivate_channel_daisy[_numChannel - 8]);
+			openBCI.serial_openBCI.write(command_deactivate_channel_daisy[_numChannel - 8]);
 		}
 	}
 
@@ -482,10 +482,10 @@ class ChannelController {
 		channelSettingValues[_numChannel][0] = '0'; //update powerUp/powerDown value of 2D array
 		if(_numChannel < 8){
 			verbosePrint("Command: " + command_activate_channel[_numChannel]);
-			serial_openBCI.write(command_activate_channel[_numChannel]);
+			openBCI.serial_openBCI.write(command_activate_channel[_numChannel]);
 		} else{ //if a daisy channel
 			verbosePrint("Command: " + command_activate_channel_daisy[_numChannel - 8]);
-			serial_openBCI.write(command_activate_channel_daisy[_numChannel - 8]);
+			openBCI.serial_openBCI.write(command_activate_channel_daisy[_numChannel - 8]);
 		}
 	}
 
@@ -538,25 +538,25 @@ class ChannelController {
 			switch (channelWriteCounter){
 				case 0: //start sequence by send 'x'
 					verbosePrint("x" + " :: " + millis());
-					serial_openBCI.write('x');
+					openBCI.serial_openBCI.write('x');
 					break;
 				case 1: //send channel number
 					verbosePrint(str(_numChannel+1) + " :: " + millis());
 					if(_numChannel < 8){
-						serial_openBCI.write((char)('0'+(_numChannel+1)));
+						openBCI.serial_openBCI.write((char)('0'+(_numChannel+1)));
 					}
 					if(_numChannel >= 8){
-						serial_openBCI.write((command_activate_channel_daisy[_numChannel-8]));
+						openBCI.serial_openBCI.write((command_activate_channel_daisy[_numChannel-8]));
 					}
 					break;
 				case 2: case 3: case 4: case 5: case 6: case 7:
 					verbosePrint(channelSettingValues[_numChannel][channelWriteCounter-2] + " :: " + millis());
-					serial_openBCI.write(channelSettingValues[_numChannel][channelWriteCounter-2]);
+					openBCI.serial_openBCI.write(channelSettingValues[_numChannel][channelWriteCounter-2]);
 					//value for ON/OF
 					break;
 				case 8:
 					verbosePrint("X" + " :: " + millis());
-					serial_openBCI.write('X'); // send 'X' to end message sequence
+					openBCI.serial_openBCI.write('X'); // send 'X' to end message sequence
 					break;
 				case 9:
 					verbosePrint("done writing channel.");
@@ -579,25 +579,25 @@ class ChannelController {
 			switch (impWriteCounter){
 				case 0: //start sequence by send 'x'
 					verbosePrint("z" + " :: " + millis());
-					serial_openBCI.write('z');
+					openBCI.serial_openBCI.write('z');
 					break;
 				case 1: //send channel number
 					verbosePrint(str(_numChannel+1) + " :: " + millis());
 					if(_numChannel < 8){
-						serial_openBCI.write((char)('0'+(_numChannel+1)));
+						openBCI.serial_openBCI.write((char)('0'+(_numChannel+1)));
 					}
 					if(_numChannel >= 8){
-						serial_openBCI.write((command_activate_channel_daisy[_numChannel-8]));
+						openBCI.serial_openBCI.write((command_activate_channel_daisy[_numChannel-8]));
 					}
 					break;
 				case 2: case 3: 
 					verbosePrint(impedanceCheckValues[_numChannel][impWriteCounter-2] + " :: " + millis());
-					serial_openBCI.write(impedanceCheckValues[_numChannel][impWriteCounter-2]);
+					openBCI.serial_openBCI.write(impedanceCheckValues[_numChannel][impWriteCounter-2]);
 					//value for ON/OF
 					break;
 				case 4:
 					verbosePrint("Z" + " :: " + millis());
-					serial_openBCI.write('Z'); // send 'X' to end message sequence
+					openBCI.serial_openBCI.write('Z'); // send 'X' to end message sequence
 					break;
 				case 5:
 					verbosePrint("done writing imp settings.");

--- a/OpenBCI_GUI/ChannelController.pde
+++ b/OpenBCI_GUI/ChannelController.pde
@@ -177,7 +177,7 @@ class ChannelController {
               impedanceCheckButtons[i][0].setString("");
             }
             if (impedanceCheckValues[i][k] == '1') {
-              impedanceCheckButtons[i][0].setColorNotPressed(greenColor);
+              impedanceCheckButtons[i][0].setColorNotPressed(isSelected_color);
               impedanceCheckButtons[i][0].setString("");
               if (showFullController) {
                 drawImpedanceValues[i] = false;
@@ -192,7 +192,7 @@ class ChannelController {
               impedanceCheckButtons[i][1].setString("");
             }
             if (impedanceCheckValues[i][k] == '1') {
-              impedanceCheckButtons[i][1].setColorNotPressed(greenColor);
+              impedanceCheckButtons[i][1].setColorNotPressed(isSelected_color);
               impedanceCheckButtons[i][1].setString("");
               if (showFullController) {
                 drawImpedanceValues[i] = false;

--- a/OpenBCI_GUI/ChannelController.pde
+++ b/OpenBCI_GUI/ChannelController.pde
@@ -131,76 +131,76 @@ class ChannelController {
       //update buttons based on channelSettingValues[i][j]
       for (int j = 0; j < numSettingsPerChannel; j++) {		
         switch(j) {  //what setting are we looking at
-        case 0: //on/off ??
-          if (channelSettingValues[i][j] == '0') channelSettingButtons[i][0].setColorNotPressed(channelColors[i%8]);// power down == false, set color to vibrant
-          if (channelSettingValues[i][j] == '1') channelSettingButtons[i][0].setColorNotPressed(color(75)); // channelSettingButtons[i][0].setString("B"); // power down == true, set color to dark gray, indicating power down
-          break;
-        case 1: //GAIN ??
-          if (channelSettingValues[i][j] == '0') channelSettingButtons[i][1].setString("x1");
-          if (channelSettingValues[i][j] == '1') channelSettingButtons[i][1].setString("x2");
-          if (channelSettingValues[i][j] == '2') channelSettingButtons[i][1].setString("x4");
-          if (channelSettingValues[i][j] == '3') channelSettingButtons[i][1].setString("x6");
-          if (channelSettingValues[i][j] == '4') channelSettingButtons[i][1].setString("x8");
-          if (channelSettingValues[i][j] == '5') channelSettingButtons[i][1].setString("x12");
-          if (channelSettingValues[i][j] == '6') channelSettingButtons[i][1].setString("x24");
-          break;
-        case 2: //input type ??
-          if (channelSettingValues[i][j] == '0') channelSettingButtons[i][2].setString("Normal");
-          if (channelSettingValues[i][j] == '1') channelSettingButtons[i][2].setString("Shorted");
-          if (channelSettingValues[i][j] == '2') channelSettingButtons[i][2].setString("BIAS_MEAS");
-          if (channelSettingValues[i][j] == '3') channelSettingButtons[i][2].setString("MVDD");
-          if (channelSettingValues[i][j] == '4') channelSettingButtons[i][2].setString("Temp.");
-          if (channelSettingValues[i][j] == '5') channelSettingButtons[i][2].setString("Test");
-          if (channelSettingValues[i][j] == '6') channelSettingButtons[i][2].setString("BIAS_DRP");
-          if (channelSettingValues[i][j] == '7') channelSettingButtons[i][2].setString("BIAS_DRN");
-          break;
-        case 3: //BIAS ??
-          if (channelSettingValues[i][j] == '0') channelSettingButtons[i][3].setString("Don't Include");
-          if (channelSettingValues[i][j] == '1') channelSettingButtons[i][3].setString("Include");
-          break;
-        case 4: // SRB2 ??
-          if (channelSettingValues[i][j] == '0') channelSettingButtons[i][4].setString("Off");
-          if (channelSettingValues[i][j] == '1') channelSettingButtons[i][4].setString("On");
-          break;
-        case 5: // SRB1 ??
-          if (channelSettingValues[i][j] == '0') channelSettingButtons[i][5].setString("No");
-          if (channelSettingValues[i][j] == '1') channelSettingButtons[i][5].setString("Yes");
-          break;
+          case 0: //on/off ??
+            if (channelSettingValues[i][j] == '0') channelSettingButtons[i][0].setColorNotPressed(channelColors[i%8]);// power down == false, set color to vibrant
+            if (channelSettingValues[i][j] == '1') channelSettingButtons[i][0].setColorNotPressed(color(75)); // channelSettingButtons[i][0].setString("B"); // power down == true, set color to dark gray, indicating power down
+            break;
+          case 1: //GAIN ??
+            if (channelSettingValues[i][j] == '0') channelSettingButtons[i][1].setString("x1");
+            if (channelSettingValues[i][j] == '1') channelSettingButtons[i][1].setString("x2");
+            if (channelSettingValues[i][j] == '2') channelSettingButtons[i][1].setString("x4");
+            if (channelSettingValues[i][j] == '3') channelSettingButtons[i][1].setString("x6");
+            if (channelSettingValues[i][j] == '4') channelSettingButtons[i][1].setString("x8");
+            if (channelSettingValues[i][j] == '5') channelSettingButtons[i][1].setString("x12");
+            if (channelSettingValues[i][j] == '6') channelSettingButtons[i][1].setString("x24");
+            break;
+          case 2: //input type ??
+            if (channelSettingValues[i][j] == '0') channelSettingButtons[i][2].setString("Normal");
+            if (channelSettingValues[i][j] == '1') channelSettingButtons[i][2].setString("Shorted");
+            if (channelSettingValues[i][j] == '2') channelSettingButtons[i][2].setString("BIAS_MEAS");
+            if (channelSettingValues[i][j] == '3') channelSettingButtons[i][2].setString("MVDD");
+            if (channelSettingValues[i][j] == '4') channelSettingButtons[i][2].setString("Temp.");
+            if (channelSettingValues[i][j] == '5') channelSettingButtons[i][2].setString("Test");
+            if (channelSettingValues[i][j] == '6') channelSettingButtons[i][2].setString("BIAS_DRP");
+            if (channelSettingValues[i][j] == '7') channelSettingButtons[i][2].setString("BIAS_DRN");
+            break;
+          case 3: //BIAS ??
+            if (channelSettingValues[i][j] == '0') channelSettingButtons[i][3].setString("Don't Include");
+            if (channelSettingValues[i][j] == '1') channelSettingButtons[i][3].setString("Include");
+            break;
+          case 4: // SRB2 ??
+            if (channelSettingValues[i][j] == '0') channelSettingButtons[i][4].setString("Off");
+            if (channelSettingValues[i][j] == '1') channelSettingButtons[i][4].setString("On");
+            break;
+          case 5: // SRB1 ??
+            if (channelSettingValues[i][j] == '0') channelSettingButtons[i][5].setString("No");
+            if (channelSettingValues[i][j] == '1') channelSettingButtons[i][5].setString("Yes");
+            break;
         }
       }
 
       for (int k = 0; k < 2; k++) {
         switch(k) {
-        case 0: // P Imp Buttons
-          if (impedanceCheckValues[i][k] == '0') {
-            impedanceCheckButtons[i][0].setColorNotPressed(color(75));
-            impedanceCheckButtons[i][0].setString("");
-          }
-          if (impedanceCheckValues[i][k] == '1') {
-            impedanceCheckButtons[i][0].setColorNotPressed(greenColor);
-            impedanceCheckButtons[i][0].setString("");
-            if (showFullController) {
-              drawImpedanceValues[i] = false;
-            } else {
-              drawImpedanceValues[i] = true;
+          case 0: // P Imp Buttons
+            if (impedanceCheckValues[i][k] == '0') {
+              impedanceCheckButtons[i][0].setColorNotPressed(color(75));
+              impedanceCheckButtons[i][0].setString("");
             }
-          }
-          break;
-        case 1: // N Imp Buttons
-          if (impedanceCheckValues[i][k] == '0') {
-            impedanceCheckButtons[i][1].setColorNotPressed(color(75));
-            impedanceCheckButtons[i][1].setString("");
-          }
-          if (impedanceCheckValues[i][k] == '1') {
-            impedanceCheckButtons[i][1].setColorNotPressed(greenColor);
-            impedanceCheckButtons[i][1].setString("");
-            if (showFullController) {
-              drawImpedanceValues[i] = false;
-            } else {
-              drawImpedanceValues[i] = true;
+            if (impedanceCheckValues[i][k] == '1') {
+              impedanceCheckButtons[i][0].setColorNotPressed(greenColor);
+              impedanceCheckButtons[i][0].setString("");
+              if (showFullController) {
+                drawImpedanceValues[i] = false;
+              } else {
+                drawImpedanceValues[i] = true;
+              }
             }
-          }
-          break;
+            break;
+          case 1: // N Imp Buttons
+            if (impedanceCheckValues[i][k] == '0') {
+              impedanceCheckButtons[i][1].setColorNotPressed(color(75));
+              impedanceCheckButtons[i][1].setString("");
+            }
+            if (impedanceCheckValues[i][k] == '1') {
+              impedanceCheckButtons[i][1].setColorNotPressed(greenColor);
+              impedanceCheckButtons[i][1].setString("");
+              if (showFullController) {
+                drawImpedanceValues[i] = false;
+              } else {
+                drawImpedanceValues[i] = true;
+              }
+            }
+            break;
         }
       }
     }
@@ -534,39 +534,39 @@ class ChannelController {
     if (millis() - timeOfLastChannelWrite >= 50) { //wait 50 milliseconds before sending next character
       verbosePrint("---");
       switch (channelWriteCounter) {
-      case 0: //start sequence by send 'x'
-        verbosePrint("x" + " :: " + millis());
-        openBCI.serial_openBCI.write('x');
-        break;
-      case 1: //send channel number
-        verbosePrint(str(_numChannel+1) + " :: " + millis());
-        if (_numChannel < 8) {
-          openBCI.serial_openBCI.write((char)('0'+(_numChannel+1)));
-        }
-        if (_numChannel >= 8) {
-          //openBCI.serial_openBCI.write((command_activate_channel_daisy[_numChannel-8]));
-          openBCI.serial_openBCI.write((command_activate_channel[_numChannel])); //command_activate_channel holds non-daisy and daisy
-        }
-        break;
-      case 2: 
-      case 3: 
-      case 4: 
-      case 5: 
-      case 6: 
-      case 7:
-        verbosePrint(channelSettingValues[_numChannel][channelWriteCounter-2] + " :: " + millis());
-        openBCI.serial_openBCI.write(channelSettingValues[_numChannel][channelWriteCounter-2]);
-        //value for ON/OF
-        break;
-      case 8:
-        verbosePrint("X" + " :: " + millis());
-        openBCI.serial_openBCI.write('X'); // send 'X' to end message sequence
-        break;
-      case 9:
-        verbosePrint("done writing channel.");
-        isWritingChannel = false;
-        channelWriteCounter = -1;
-        break;
+        case 0: //start sequence by send 'x'
+          verbosePrint("x" + " :: " + millis());
+          openBCI.serial_openBCI.write('x');
+          break;
+        case 1: //send channel number
+          verbosePrint(str(_numChannel+1) + " :: " + millis());
+          if (_numChannel < 8) {
+            openBCI.serial_openBCI.write((char)('0'+(_numChannel+1)));
+          }
+          if (_numChannel >= 8) {
+            //openBCI.serial_openBCI.write((command_activate_channel_daisy[_numChannel-8]));
+            openBCI.serial_openBCI.write((command_activate_channel[_numChannel])); //command_activate_channel holds non-daisy and daisy
+          }
+          break;
+        case 2: 
+        case 3: 
+        case 4: 
+        case 5: 
+        case 6: 
+        case 7:
+          verbosePrint(channelSettingValues[_numChannel][channelWriteCounter-2] + " :: " + millis());
+          openBCI.serial_openBCI.write(channelSettingValues[_numChannel][channelWriteCounter-2]);
+          //value for ON/OF
+          break;
+        case 8:
+          verbosePrint("X" + " :: " + millis());
+          openBCI.serial_openBCI.write('X'); // send 'X' to end message sequence
+          break;
+        case 9:
+          verbosePrint("done writing channel.");
+          isWritingChannel = false;
+          channelWriteCounter = -1;
+          break;
       }
       timeOfLastChannelWrite = millis();
       channelWriteCounter++;
@@ -581,35 +581,35 @@ class ChannelController {
     if (millis() - timeOfLastImpWrite >= 50) { //wait 50 milliseconds before sending next character
       verbosePrint("---");
       switch (impWriteCounter) {
-      case 0: //start sequence by sending 'z'
-        verbosePrint("z" + " :: " + millis());
-        openBCI.serial_openBCI.write('z');
-        break;
-      case 1: //send channel number
-        verbosePrint(str(_numChannel+1) + " :: " + millis());
-        if (_numChannel < 8) {
-          openBCI.serial_openBCI.write((char)('0'+(_numChannel+1)));
-        }
-        if (_numChannel >= 8) {
-          //openBCI.serial_openBCI.write((command_activate_channel_daisy[_numChannel-8]));
-          openBCI.serial_openBCI.write((command_activate_channel[_numChannel])); //command_activate_channel holds non-daisy and daisy values
-        }
-        break;
-      case 2: 
-      case 3: 
-        verbosePrint(impedanceCheckValues[_numChannel][impWriteCounter-2] + " :: " + millis());
-        openBCI.serial_openBCI.write(impedanceCheckValues[_numChannel][impWriteCounter-2]);
-        //value for ON/OF
-        break;
-      case 4:
-        verbosePrint("Z" + " :: " + millis());
-        openBCI.serial_openBCI.write('Z'); // send 'X' to end message sequence
-        break;
-      case 5:
-        verbosePrint("done writing imp settings.");
-        isWritingImp = false;
-        impWriteCounter = -1;
-        break;
+        case 0: //start sequence by sending 'z'
+          verbosePrint("z" + " :: " + millis());
+          openBCI.serial_openBCI.write('z');
+          break;
+        case 1: //send channel number
+          verbosePrint(str(_numChannel+1) + " :: " + millis());
+          if (_numChannel < 8) {
+            openBCI.serial_openBCI.write((char)('0'+(_numChannel+1)));
+          }
+          if (_numChannel >= 8) {
+            //openBCI.serial_openBCI.write((command_activate_channel_daisy[_numChannel-8]));
+            openBCI.serial_openBCI.write((command_activate_channel[_numChannel])); //command_activate_channel holds non-daisy and daisy values
+          }
+          break;
+        case 2: 
+        case 3: 
+          verbosePrint(impedanceCheckValues[_numChannel][impWriteCounter-2] + " :: " + millis());
+          openBCI.serial_openBCI.write(impedanceCheckValues[_numChannel][impWriteCounter-2]);
+          //value for ON/OF
+          break;
+        case 4:
+          verbosePrint("Z" + " :: " + millis());
+          openBCI.serial_openBCI.write('Z'); // send 'X' to end message sequence
+          break;
+        case 5:
+          verbosePrint("done writing imp settings.");
+          isWritingImp = false;
+          impWriteCounter = -1;
+          break;
       }
       timeOfLastImpWrite = millis();
       impWriteCounter++;

--- a/OpenBCI_GUI/ChannelController.pde
+++ b/OpenBCI_GUI/ChannelController.pde
@@ -105,11 +105,11 @@ class ChannelController {
     for (int i = 0; i < nchan; i++) {
       verbosePrint("chan: " + i + " ");
       for (int j = 0; j < numSettingsPerChannel; j++) { //channel setting values
-        channelSettingValues[i][j] = char(openBCI.defaultChannelSettings.toCharArray()[j]); //parse defaultChannelSettings string created in the OpenBCI_ADS1299 class
+        channelSettingValues[i][j] = char(openBCI.get_defaultChannelSettings().toCharArray()[j]); //parse defaultChannelSettings string created in the OpenBCI_ADS1299 class
         if (j == numSettingsPerChannel - 1) {
-          println(char(openBCI.defaultChannelSettings.toCharArray()[j]));
+          println(char(openBCI.get_defaultChannelSettings().toCharArray()[j]));
         } else {
-          print(char(openBCI.defaultChannelSettings.toCharArray()[j]) + ",");
+          print(char(openBCI.get_defaultChannelSettings().toCharArray()[j]) + ",");
         }
       }
       for (int k = 0; k < 2; k++) { //impedance setting values
@@ -207,20 +207,20 @@ class ChannelController {
     //then reset to 1
 
     //
-    if (openBCI.isWritingChannel) {
+    if (openBCI.get_isWritingChannel()) {
       openBCI.writeChannelSettings(channelToWrite,channelSettingValues);
     }
 
-    if (rewriteChannelWhenDoneWriting == true && openBCI.isWritingChannel == false) {
+    if (rewriteChannelWhenDoneWriting == true && openBCI.get_isWritingChannel() == false) {
       initChannelWrite(channelToWriteWhenDoneWriting);
       rewriteChannelWhenDoneWriting = false;
     }
 
-    if (openBCI.isWritingImp) {
+    if (openBCI.get_isWritingImp()) {
       openBCI.writeImpedanceSettings(impChannelToWrite,impedanceCheckValues);
     }
 
-    if (rewriteImpedanceWhenDoneWriting == true && openBCI.isWritingImp == false) {
+    if (rewriteImpedanceWhenDoneWriting == true && openBCI.get_isWritingImp() == false) {
       initImpWrite(impChannelToWriteWhenDoneWriting, final_pORn, final_onORoff);
       rewriteImpedanceWhenDoneWriting = false;
     }
@@ -368,7 +368,7 @@ class ChannelController {
               channelSettingValues[i][j] = '0';
             }	
             // if you're not currently writing a channel and not waiting to rewrite after you've finished mashing the button
-            if (!openBCI.isWritingChannel && rewriteChannelWhenDoneWriting == false) {
+            if (!openBCI.get_isWritingChannel() && rewriteChannelWhenDoneWriting == false) {
               initChannelWrite(i);//write new ADS1299 channel row values to OpenBCI
             } else { //else wait until a the current write has finished and then write again ... this is to not overwrite the wrong values while writing a channel
               verbosePrint("CONGRATULATIONS, YOU'RE MASHING BUTTONS!");
@@ -490,7 +490,7 @@ class ChannelController {
 
   public void initChannelWrite(int _numChannel) {
     //after clicking any button, write the new settings for that channel to OpenBCI
-    if (!openBCI.isWritingImp) { //make sure you aren't currently writing imp settings for a channel
+    if (!openBCI.get_isWritingImp()) { //make sure you aren't currently writing imp settings for a channel
       verbosePrint("Writing channel settings for channel " + str(_numChannel+1) + " to OpenBCI!");
       openBCI.initChannelWrite(_numChannel);
       channelToWrite = _numChannel;
@@ -499,9 +499,9 @@ class ChannelController {
 
   public void initImpWrite(int _numChannel, char pORn, char onORoff) {
     //after clicking any button, write the new settings for that channel to OpenBCI
-    if (!openBCI.isWritingChannel) { //make sure you aren't currently writing imp settings for a channel
+    if (!openBCI.get_isWritingChannel()) { //make sure you aren't currently writing imp settings for a channel
       // if you're not currently writing a channel and not waiting to rewrite after you've finished mashing the button
-      if (!openBCI.isWritingImp && rewriteImpedanceWhenDoneWriting == false) {
+      if (!openBCI.get_isWritingImp() && rewriteImpedanceWhenDoneWriting == false) {
         verbosePrint("Writing impedance check settings (" + pORn + "," + onORoff +  ") for channel " + str(_numChannel+1) + " to OpenBCI!");
         if (pORn == 'p') {
           impedanceCheckValues[_numChannel][0] = onORoff;

--- a/OpenBCI_GUI/ChannelController.pde
+++ b/OpenBCI_GUI/ChannelController.pde
@@ -5,665 +5,667 @@ int numSettingsPerChannel = 6; //each channel has 6 different settings
 char[][] channelSettingValues = new char [nchan][numSettingsPerChannel]; // [channel#][Button#-value] ... this will incfluence text of button
 char[][] impedanceCheckValues = new char [nchan][2];
 
-public void updateChannelArrays(int _nchan){
-	channelSettingValues = new char [_nchan][numSettingsPerChannel]; // [channel#][Button#-value] ... this will incfluence text of button
-	impedanceCheckValues = new char [_nchan][2];
+public void updateChannelArrays(int _nchan) {
+  channelSettingValues = new char [_nchan][numSettingsPerChannel]; // [channel#][Button#-value] ... this will incfluence text of button
+  impedanceCheckValues = new char [_nchan][2];
 }
 
 // color[] channelColors = new color[16];
 color[] channelColors = {
-	color(129, 129, 129), 
-	color(124, 75, 141), 
-	color(54, 87, 158), 
-	color(49, 113, 89),
-	color(221, 178, 13),
-	color(253, 94, 52),
-	color(224, 56, 45),
-	color(162, 82, 49)
+  color(129, 129, 129), 
+  color(124, 75, 141), 
+  color(54, 87, 158), 
+  color(49, 113, 89), 
+  color(221, 178, 13), 
+  color(253, 94, 52), 
+  color(224, 56, 45), 
+  color(162, 82, 49)
 };
 
 class ChannelController {
 
-	public float x1, y1, w1, h1, x2, y2, w2, h2; //all 1 values refer to the left panel that is always visible ... al 2 values refer to the right panel that is only visible when showFullController = true
-	public int montage_w, montage_h;
-	public int rowHeight;
-	public int buttonSpacing;
-	boolean showFullController = false;
-	boolean[] drawImpedanceValues = new boolean [nchan];
-
-	int spacer1 = 3;
-	int spacer2 = 5; //space between buttons
-
-	// [Number of Channels] x 6 array of buttons for channel settings
-	Button[][] channelSettingButtons = new Button [nchan][numSettingsPerChannel];  // [channel#][Button#]
-	// char[][] channelSettingValues = new char [nchan][numSettingsPerChannel]; // [channel#][Button#-value] ... this will incfluence text of button
-
-	//buttons just to the left of 
-	Button[][] impedanceCheckButtons = new Button [nchan][2];
-	// char [][] impedanceCheckValues = new char [nchan][2];
-
-	// Array for storing SRB2 history settings of channels prior to shutting off .. so you can return to previous state when reactivating channel
-	char[] previousSRB2 = new char [nchan];
-	// Array for storing SRB2 history settings of channels prior to shutting off .. so you can return to previous state when reactivating channel
-	char[] previousBIAS = new char [nchan];
-
-	//maximum different values for the different settings (Power Down, Gain, Input Type, BIAS, SRB2, SRB1) of 
-	//refer to page 44 of ADS1299 Datasheet: http://www.ti.com/lit/ds/symlink/ads1299.pdf
-	char[] maxValuesPerSetting = {
-		'1', // Power Down :: (0)ON, (1)OFF
-		'6', // Gain :: (0) x1, (1) x2, (2) x4, (3) x6, (4) x8, (5) x12, (6) x24 ... default
-		'7', // Channel Input :: (0)Normal Electrode Input, (1)Input Shorted, (2)Used in conjunction with BIAS_MEAS, (3)MVDD for supply measurement, (4)Temperature Sensor, (5)Test Signal, (6)BIAS_DRP ... positive electrode is driver, (7)BIAS_DRN ... negative electrode is driver
-		'1', // BIAS :: (0) Yes, (1) No
-		'1', // SRB2 :: (0) Open, (1) Closed
-		'1'}; // SRB1 :: (0) Yes, (1) No ... this setting affects all channels ... either all on or all off
-
-	//variables used for channel write timing in writeChannelSettings()
-	long timeOfLastChannelWrite = 0;
-	int channelToWrite = -1;
-	int channelWriteCounter = 0;
-	boolean isWritingChannel = false;
-
-	//variables use for imp write timing with writeImpedanceSettings()
-	long timeOfLastImpWrite = 0;
-	int impChannelToWrite = -1;
-	int impWriteCounter = 0;
-	boolean isWritingImp = false;
-
-	boolean rewriteChannelWhenDoneWriting = false;
-	int channelToWriteWhenDoneWriting = 0;
-
-	boolean rewriteImpedanceWhenDoneWriting = false;
-	int impChannelToWriteWhenDoneWriting = 0;
-	char final_pORn = '0';
-	char final_onORoff = '0';
-
-	ChannelController(float _xPos, float _yPos, float _width, float _height, float _montage_w, float _montage_h){
-		//positioning values for left panel (that is always visible)
-		x1 = _xPos;
-		y1 = _yPos;
-		w1 = _width;
-		h1 = _height;
-
-		//positioning values for right panel that is only visible when showFullController = true (behind the graph)
-		x2 = x1 + w1;
-		// x2 = gui.showMontageButton.but_x;
-		y2 = y1;
-		w2 = _montage_w;
-		h2 = h1;
-
-		createChannelSettingButtons();
-
-		// set on/off buttons to default channel colors
-		for(int i = 0; i < nchan; i++){
-			channelSettingButtons[i][0].setColorNotPressed(channelColors[i%8]);
-		}
-	}
-
-	public void loadDefaultChannelSettings(){
-		verbosePrint("ChannelController: loading default channel settings to GUI's channel controller...");
-		for(int i = 0; i < nchan; i++){
-			verbosePrint("chan: " + i + " ");
-			for(int j = 0; j < numSettingsPerChannel; j++){ //channel setting values
-				channelSettingValues[i][j] = char(openBCI.defaultChannelSettings.toCharArray()[j]); //parse defaultChannelSettings string created in the OpenBCI_ADS1299 class
-				if(j == numSettingsPerChannel - 1){
-					println(char(openBCI.defaultChannelSettings.toCharArray()[j]));
-				} else{
-					print(char(openBCI.defaultChannelSettings.toCharArray()[j]) + ",");
-				}
-			}
-			for(int k = 0; k < 2; k++){ //impedance setting values
-				impedanceCheckValues[i][k] = '0';
-			}
-		}
-		verbosePrint("made it!");
-		update(); //update 1 time to refresh button values based on new loaded settings
-	}
-
-	public void update(){
-
-		//make false to check again below
-		for(int i = 0; i < nchan; i++){
-			drawImpedanceValues[i] = false;
-		}
-
-		for(int i = 0; i < nchan; i++){ //for every channel
-			//update buttons based on channelSettingValues[i][j]
-			for(int j = 0; j < numSettingsPerChannel; j++){		
-				switch(j){  //what setting are we looking at
-					case 0: //on/off ??
-						if(channelSettingValues[i][j] == '0') channelSettingButtons[i][0].setColorNotPressed(channelColors[i%8]);// power down == false, set color to vibrant
-						if(channelSettingValues[i][j] == '1') channelSettingButtons[i][0].setColorNotPressed(color(75)); // channelSettingButtons[i][0].setString("B"); // power down == true, set color to dark gray, indicating power down
-						break;
-					case 1: //GAIN ??
-						if(channelSettingValues[i][j] == '0') channelSettingButtons[i][1].setString("x1");
-						if(channelSettingValues[i][j] == '1') channelSettingButtons[i][1].setString("x2");
-						if(channelSettingValues[i][j] == '2') channelSettingButtons[i][1].setString("x4");
-						if(channelSettingValues[i][j] == '3') channelSettingButtons[i][1].setString("x6");
-						if(channelSettingValues[i][j] == '4') channelSettingButtons[i][1].setString("x8");
-						if(channelSettingValues[i][j] == '5') channelSettingButtons[i][1].setString("x12");
-						if(channelSettingValues[i][j] == '6') channelSettingButtons[i][1].setString("x24");
-						break;
-					case 2: //input type ??
-						if(channelSettingValues[i][j] == '0') channelSettingButtons[i][2].setString("Normal");
-						if(channelSettingValues[i][j] == '1') channelSettingButtons[i][2].setString("Shorted");
-						if(channelSettingValues[i][j] == '2') channelSettingButtons[i][2].setString("BIAS_MEAS");
-						if(channelSettingValues[i][j] == '3') channelSettingButtons[i][2].setString("MVDD");
-						if(channelSettingValues[i][j] == '4') channelSettingButtons[i][2].setString("Temp.");
-						if(channelSettingValues[i][j] == '5') channelSettingButtons[i][2].setString("Test");
-						if(channelSettingValues[i][j] == '6') channelSettingButtons[i][2].setString("BIAS_DRP");
-						if(channelSettingValues[i][j] == '7') channelSettingButtons[i][2].setString("BIAS_DRN");
-						break;
-					case 3: //BIAS ??
-						if(channelSettingValues[i][j] == '0') channelSettingButtons[i][3].setString("Don't Include");
-						if(channelSettingValues[i][j] == '1') channelSettingButtons[i][3].setString("Include");
-						break;
-					case 4: // SRB2 ??
-						if(channelSettingValues[i][j] == '0') channelSettingButtons[i][4].setString("Off");
-						if(channelSettingValues[i][j] == '1') channelSettingButtons[i][4].setString("On");
-						break;
-					case 5: // SRB1 ??
-						if(channelSettingValues[i][j] == '0') channelSettingButtons[i][5].setString("No");
-						if(channelSettingValues[i][j] == '1') channelSettingButtons[i][5].setString("Yes");
-						break;
-				}
-			}
-
-			for(int k = 0; k < 2; k++){
-				switch(k){
-					case 0: // P Imp Buttons
-						if(impedanceCheckValues[i][k] == '0'){
-							impedanceCheckButtons[i][0].setColorNotPressed(color(75));
-							impedanceCheckButtons[i][0].setString("");
-						}
-						if(impedanceCheckValues[i][k] == '1'){
-							impedanceCheckButtons[i][0].setColorNotPressed(greenColor);
-							impedanceCheckButtons[i][0].setString("");
-							if(showFullController){
-								drawImpedanceValues[i] = false;
-							}else{
-								drawImpedanceValues[i] = true;
-							}
-						}
-						break;
-					case 1: // N Imp Buttons
-						if(impedanceCheckValues[i][k] == '0'){
-							impedanceCheckButtons[i][1].setColorNotPressed(color(75));
-							impedanceCheckButtons[i][1].setString("");
-						}
-						if(impedanceCheckValues[i][k] == '1'){
-							impedanceCheckButtons[i][1].setColorNotPressed(greenColor);
-							impedanceCheckButtons[i][1].setString("");
-							if(showFullController){
-								drawImpedanceValues[i] = false;
-							}else{
-								drawImpedanceValues[i] = true;
-							}
-						}
-						break;
-				}
-			}
-		}
-		//then reset to 1
-
-		//
-		if(isWritingChannel){
-			writeChannelSettings(channelToWrite);
-		}
-
-		if(rewriteChannelWhenDoneWriting == true && isWritingChannel == false){
-			initChannelWrite(channelToWriteWhenDoneWriting);
-			rewriteChannelWhenDoneWriting = false;
-		}
-
-		if(isWritingImp){
-			writeImpedanceSettings(impChannelToWrite);
-		}
-
-		if(rewriteImpedanceWhenDoneWriting == true && isWritingImp == false){
-			initImpWrite(impChannelToWriteWhenDoneWriting, final_pORn, final_onORoff);
-			rewriteImpedanceWhenDoneWriting = false;
-		}
-	}
-
-	public void draw(){
-
-		pushStyle();
-		noStroke();
-
-		//draw phantom rectangle to cover up random crap from Graph2D... we are replacing this stuff with the Montage Controller
-		fill(bgColor);
-		rect(x1 - 2, y1-(height*0.01f), w1, h1+(height*0.02f));
-
-		//draw light green rect behind pane title
-		fill(216,233,171);
-		rect(x2-2,y2-25,w2+1,25);
-
-		//BG of montage controller (for debugging mainly)
-		// fill(255,255,255,123);
-		// rect(x1, y1 - 1, w1, h1);
-
-		//draw background pane of impedance buttons
-		fill(221);
-		rect(x1 + w1/3 + 1, y1, 2*(w1/3) - 3, h1 - 2);
-
-		//draw slightly darker line guides/separators for impedance buttons
-		stroke(175);
-		strokeWeight(2);
-		for(int i = 0; i < nchan; i++){
-			line(x1 + w1/3 + 2, y1 + (((h1-1)/(nchan+1))*(i+1)), x2 - 3, y1 + (((h1-1)/(nchan+1))*(i+1)));
-		}
-		line(x1 + 2*(w1/3) - 1, y1 + 1, x1 + 2*(w1/3) - 1, y1 + (h1-1) - 1);
-		strokeWeight(0);
-
-		//channel buttons
-		for(int i = 0; i < nchan; i++){
-			channelSettingButtons[i][0].draw(); //draw on/off channel buttons
-			//draw impedance buttons
-			for(int j = 0; j < 2; j++){
-				impedanceCheckButtons[i][j].draw();
-			}
-		}
-
-		//label impedance button columns
-		fill(bgColor);
-		text("P", x1 + 1*(w1/2), y1 + 12);
-		text("N", x1 + 5*(w1/6) - 2, y1 + 12);
-
-		if(showFullController){
-			//background
-			noStroke();
-			fill(0,0,0,100);
-			rect(x1 + w1, y1, w2, h2);
-
-			// [numChan] x 5 ... all channel setting buttons (other than on/off) 
-			for(int i = 0; i < nchan; i++){
-				for(int j = 1; j < 6; j++){
-					// println("drawing button " + i + "," + j);
-					// println("Button: " + channelSettingButtons[i][j]);
-					channelSettingButtons[i][j].draw();
-				}
-			}
-
-			//draw column headers for channel settings behind EEG graph
-			fill(bgColor);
-			text("PGA Gain", x2 + (w2/10)*1, y1 - 12);
-			text("Input Type", x2 + (w2/10)*3, y1 - 12);
-			text("  Bias ", x2 + (w2/10)*5, y1 - 12);
-			text("SRB2", x2 + (w2/10)*7, y1 - 12);
-			text("SRB1", x2 + (w2/10)*9, y1 - 12);
-
-			//if mode is not from OpenBCI, draw a dark overlay to indicate that you cannot edit these settings
-			if(eegDataSource != DATASOURCE_NORMAL && eegDataSource != DATASOURCE_NORMAL_W_AUX){
-				fill(0,0,0,200);
-				noStroke();
-				rect(x2-2,y2,w2+1,h2);
-				fill(255);
-				textSize(24);
-				text("DATA SOURCE (LIVE) only", x2 + (w2/2), y2 + (h2/2));
-			}
-		}
-
-		if ((eegDataSource != DATASOURCE_NORMAL) && (eegDataSource != DATASOURCE_NORMAL_W_AUX)) {
-			fill(0,0,0,200);
-			rect(x1 + w1/3 + 1, y1, 2*(w1/3) - 3, h1 - 2);
-		}
-
-		for (int i = 0; i < nchan; i++){
-			if (drawImpedanceValues[i] == true) {
-				gui.impValuesMontage[i].draw();  //impedance values on montage plot
-	                }
-		}
-
-		popStyle();
-
-	}
-
-	public void mousePressed(){
-		//if fullChannelController and one of the buttons (other than ON/OFF) is clicked
-
-		//if dataSource is coming from OpenBCI, allow user to interact with channel controller
-		if ( (eegDataSource == DATASOURCE_NORMAL) || (eegDataSource == DATASOURCE_NORMAL_W_AUX) ) {
-			if (showFullController) {
-				for (int i = 0; i < nchan; i++) { //When [i][j] button is clicked
-					for (int j = 1; j < numSettingsPerChannel; j++) {		
-						if (channelSettingButtons[i][j].isMouseHere()) {
-							//increment [i][j] channelSettingValue by, until it reaches max values per setting [j], 
-							channelSettingButtons[i][j].wasPressed = true;
-							channelSettingButtons[i][j].isActive = true;
-						}
-					}
-				}	
-			}
-		}
-		//on/off button and Imp buttons can always be clicked/released
-		for(int i = 0; i < nchan; i++){
-			if(channelSettingButtons[i][0].isMouseHere()){
-				channelSettingButtons[i][0].wasPressed = true;
-				channelSettingButtons[i][0].isActive = true;
-			}
-
-			//only allow editing of impedance if dataSource == from OpenBCI
-			if ((eegDataSource == DATASOURCE_NORMAL) || (eegDataSource == DATASOURCE_NORMAL_W_AUX)) {
-				if(impedanceCheckButtons[i][0].isMouseHere()){
-					impedanceCheckButtons[i][0].wasPressed = true;
-					impedanceCheckButtons[i][0].isActive = true;
-				}
-				if(impedanceCheckButtons[i][1].isMouseHere()){
-					impedanceCheckButtons[i][1].wasPressed = true;
-					impedanceCheckButtons[i][1].isActive = true;
-				}
-			}
-		}
-
-	}
-
-	public void mouseReleased(){
-		//if fullChannelController and one of the buttons (other than ON/OFF) is released
-		if(showFullController){
-			for(int i = 0; i < nchan; i++){ //When [i][j] button is clicked
-				for(int j = 1; j < numSettingsPerChannel; j++){		
-					if(channelSettingButtons[i][j].isMouseHere() && channelSettingButtons[i][j].wasPressed == true){
-						if(channelSettingValues[i][j] < maxValuesPerSetting[j]){
-							channelSettingValues[i][j]++;	//increment [i][j] channelSettingValue by, until it reaches max values per setting [j], 
-						} else {
-							channelSettingValues[i][j] = '0';
-						}	
-						// if you're not currently writing a channel and not waiting to rewrite after you've finished mashing the button
-						if(!isWritingChannel && rewriteChannelWhenDoneWriting == false){
-							initChannelWrite(i);//write new ADS1299 channel row values to OpenBCI
-						}
-						else{ //else wait until a the current write has finished and then write again ... this is to not overwrite the wrong values while writing a channel
-							verbosePrint("CONGRATULATIONS, YOU'RE MASHING BUTTONS!");
-							rewriteChannelWhenDoneWriting = true;
-							channelToWriteWhenDoneWriting = i;
-						}
-
-					}
-
-					// if(!channelSettingButtons[i][j].isMouseHere()){
-					channelSettingButtons[i][j].isActive = false;
-					channelSettingButtons[i][j].wasPressed = false;
-					// }
-				}
-			}
-		}
-		//ON/OFF button can always be clicked/released
-		for(int i = 0; i < nchan; i++){
-			//was on/off clicked?
-			if(channelSettingButtons[i][0].isMouseHere() && channelSettingButtons[i][0].wasPressed == true){
-				if(channelSettingValues[i][0] < maxValuesPerSetting[0]){
-					channelSettingValues[i][0] = '1';	//increment [i][j] channelSettingValue by, until it reaches max values per setting [j], 
-					// channelSettingButtons[i][0].setColorNotPressed(color(25,25,25));
-					// powerDownChannel(i);
-					deactivateChannel(i);
-				} else {
-					channelSettingValues[i][0] = '0';
-					// channelSettingButtons[i][0].setColorNotPressed(color(255));
-					// powerUpChannel(i);
-					activateChannel(i);
-				}
-				// writeChannelSettings(i);//write new ADS1299 channel row values to OpenBCI
-			}
-
-			//was P imp check button clicked?
-			if(impedanceCheckButtons[i][0].isMouseHere() && impedanceCheckButtons[i][0].wasPressed == true){
-				if(impedanceCheckValues[i][0] < '1'){
-					// impedanceCheckValues[i][0] = '1';	//increment [i][j] channelSettingValue by, until it reaches max values per setting [j], 
-					// channelSettingButtons[i][0].setColorNotPressed(color(25,25,25));
-					// writeImpedanceSettings(i);
-					initImpWrite(i, 'p', '1');
-					//initImpWrite
-					verbosePrint("a");
-				} else {
-					// impedanceCheckValues[i][0] = '0';
-					// channelSettingButtons[i][0].setColorNotPressed(color(255));
-					// writeImpedanceSettings(i);
-					initImpWrite(i, 'p', '0');
-					verbosePrint("b");
-				}
-				// writeChannelSettings(i);//write new ADS1299 channel row values to OpenBCI
-			}
-
-			//was N imp check button clicked?
-			if(impedanceCheckButtons[i][1].isMouseHere() && impedanceCheckButtons[i][1].wasPressed == true){
-				if(impedanceCheckValues[i][1] < '1'){
-					initImpWrite(i, 'n', '1');
-					//initImpWrite
-					verbosePrint("c");
-				} else {
-					initImpWrite(i, 'n', '0');
-					verbosePrint("d");
-				}
-				// writeChannelSettings(i);//write new ADS1299 channel row values to OpenBCI
-			}
-
-			channelSettingButtons[i][0].isActive = false;
-			channelSettingButtons[i][0].wasPressed = false;
-			impedanceCheckButtons[i][0].isActive = false;
-			impedanceCheckButtons[i][0].wasPressed = false;
-			impedanceCheckButtons[i][1].isActive = false;
-			impedanceCheckButtons[i][1].wasPressed = false;
-		}
-
-		update(); //update once to refresh button values
-	}
-
-	public void fillValuesBasedOnDefault(byte _defaultValues){
-		//interpret incoming HEX value (from OpenBCI) and pass into all default channelSettingValues
-		//dencode byte from OpenBCI and break it apart into the channelSettingValues[][] array
-	}
-
-	public void powerDownChannel(int _numChannel){
-		verbosePrint("Powering down channel " + str(int(_numChannel) + int(1)));
-		//save SRB2 and BIAS settings in 2D history array (to turn back on when channel is reactivated)
-		previousBIAS[_numChannel] = channelSettingValues[_numChannel][3];
-		previousSRB2[_numChannel] = channelSettingValues[_numChannel][4];
-		channelSettingValues[_numChannel][3] = '0'; //make sure to disconnect from BIAS
-		channelSettingValues[_numChannel][4] = '0'; //make sure to disconnect from SRB2
-
-		// initChannelWrite(_numChannel);//writeChannelSettings
-		channelSettingValues[_numChannel][0] = '1'; //update powerUp/powerDown value of 2D array
-		//if(_numChannel < 8){
-			verbosePrint("Command: " + command_deactivate_channel[_numChannel]);
-			//openBCI.serial_openBCI.write(command_deactivate_channel[_numChannel]);
-                        openBCI.deactivateChannel(_numChannel);  //assumes numChannel counts from zero (not one)...handles regular and daisy channels
-		//}else{ //if a daisy channel
-		//	verbosePrint("Command: " + command_deactivate_channel_daisy[_numChannel - 8]);
-		//	openBCI.serial_openBCI.write(command_deactivate_channel_daisy[_numChannel - 8]);
-		//}
-	}
-
-	public void powerUpChannel(int _numChannel){
-		verbosePrint("Powering up channel " + str(int(_numChannel) + int(1)));
-		//replace SRB2 and BIAS settings with values from 2D history array
-		channelSettingValues[_numChannel][3] = previousBIAS[_numChannel];
-		channelSettingValues[_numChannel][4] = previousSRB2[_numChannel];
-
-		// initChannelWrite(_numChannel);//writeChannelSettings
-		channelSettingValues[_numChannel][0] = '0'; //update powerUp/powerDown value of 2D array
-		//if(_numChannel < 8){
-			verbosePrint("Command: " + command_activate_channel[_numChannel]);
-			//openBCI.serial_openBCI.write(command_activate_channel[_numChannel]);
-                        openBCI.activateChannel(_numChannel);  //assumes numChannel counts from zero (not one)...handles regular and daisy channels//assumes numChannel counts from zero (not one)...handles regular and daisy channels
-		//} else{ //if a daisy channel
-		//	verbosePrint("Command: " + command_activate_channel_daisy[_numChannel - 8]);
-		//	openBCI.serial_openBCI.write(command_activate_channel_daisy[_numChannel - 8]);
-		//}
-	}
-
-	public void initChannelWrite(int _numChannel){
-		//after clicking any button, write the new settings for that channel to OpenBCI
-		if(!isWritingImp){ //make sure you aren't currently writing imp settings for a channel
-			verbosePrint("Writing channel settings for channel " + str(_numChannel+1) + " to OpenBCI!");
-			timeOfLastChannelWrite = millis();
-			isWritingChannel = true;
-			channelToWrite = _numChannel;
-		}
-	}
-
-	public void initImpWrite(int _numChannel, char pORn, char onORoff){
-		//after clicking any button, write the new settings for that channel to OpenBCI
-		if(!isWritingChannel){ //make sure you aren't currently writing imp settings for a channel
-			// if you're not currently writing a channel and not waiting to rewrite after you've finished mashing the button
-			if(!isWritingImp && rewriteImpedanceWhenDoneWriting == false){
-				verbosePrint("Writing impedance check settings (" + pORn + "," + onORoff +  ") for channel " + str(_numChannel+1) + " to OpenBCI!");
-				if(pORn == 'p'){
-					impedanceCheckValues[_numChannel][0] = onORoff;
-				}
-				if(pORn == 'n'){
-					impedanceCheckValues[_numChannel][1] = onORoff;
-				}
-
-				timeOfLastImpWrite = millis();
-				isWritingImp = true;
-				impChannelToWrite = _numChannel;
-			}
-			else{ //else wait until a the current write has finished and then write again ... this is to not overwrite the wrong values while writing a channel
-				verbosePrint("CONGRATULATIONS, YOU'RE MASHING BUTTONS!");
-				rewriteImpedanceWhenDoneWriting = true;
-				impChannelToWriteWhenDoneWriting = _numChannel;
-
-				if(pORn == 'p'){
-					final_pORn = 'p';
-				}
-				if(pORn == 'n'){
-					final_pORn = 'n';
-				}
-				final_onORoff = onORoff;
-			}
-		}
-	}
-
-	public void writeChannelSettings(int _numChannel){
-		if(millis() - timeOfLastChannelWrite >= 50){ //wait 50 milliseconds before sending next character
-			verbosePrint("---");
-			switch (channelWriteCounter){
-				case 0: //start sequence by send 'x'
-					verbosePrint("x" + " :: " + millis());
-					openBCI.serial_openBCI.write('x');
-					break;
-				case 1: //send channel number
-					verbosePrint(str(_numChannel+1) + " :: " + millis());
-					if(_numChannel < 8){
-						openBCI.serial_openBCI.write((char)('0'+(_numChannel+1)));
-					}
-					if(_numChannel >= 8){
-						//openBCI.serial_openBCI.write((command_activate_channel_daisy[_numChannel-8]));
-                                                openBCI.serial_openBCI.write((command_activate_channel[_numChannel])); //command_activate_channel holds non-daisy and daisy
-					}
-					break;
-				case 2: case 3: case 4: case 5: case 6: case 7:
-					verbosePrint(channelSettingValues[_numChannel][channelWriteCounter-2] + " :: " + millis());
-					openBCI.serial_openBCI.write(channelSettingValues[_numChannel][channelWriteCounter-2]);
-					//value for ON/OF
-					break;
-				case 8:
-					verbosePrint("X" + " :: " + millis());
-					openBCI.serial_openBCI.write('X'); // send 'X' to end message sequence
-					break;
-				case 9:
-					verbosePrint("done writing channel.");
-					isWritingChannel = false;
-					channelWriteCounter = -1;
-					break;
-			}
-			timeOfLastChannelWrite = millis();
-			channelWriteCounter++;
-		}
-	}
-
-	public void writeImpedanceSettings(int _numChannel){
-		//after clicking an impedance button, write the new impedance settings for that channel to OpenBCI
-			//after clicking any button, write the new settings for that channel to OpenBCI
-		// verbosePrint("Writing impedance settings for channel " + _numChannel + " to OpenBCI!");
-		//write setting 1, delay 5ms.. write setting 2, delay 5ms, etc.
-		if(millis() - timeOfLastImpWrite >= 50){ //wait 50 milliseconds before sending next character
-			verbosePrint("---");
-			switch (impWriteCounter){
-				case 0: //start sequence by sending 'z'
-					verbosePrint("z" + " :: " + millis());
-					openBCI.serial_openBCI.write('z');
-					break;
-				case 1: //send channel number
-					verbosePrint(str(_numChannel+1) + " :: " + millis());
-					if(_numChannel < 8){
-						openBCI.serial_openBCI.write((char)('0'+(_numChannel+1)));
-					}
-					if(_numChannel >= 8){
-						//openBCI.serial_openBCI.write((command_activate_channel_daisy[_numChannel-8]));
-                                                openBCI.serial_openBCI.write((command_activate_channel[_numChannel])); //command_activate_channel holds non-daisy and daisy values
-					}
-					break;
-				case 2: case 3: 
-					verbosePrint(impedanceCheckValues[_numChannel][impWriteCounter-2] + " :: " + millis());
-					openBCI.serial_openBCI.write(impedanceCheckValues[_numChannel][impWriteCounter-2]);
-					//value for ON/OF
-					break;
-				case 4:
-					verbosePrint("Z" + " :: " + millis());
-					openBCI.serial_openBCI.write('Z'); // send 'X' to end message sequence
-					break;
-				case 5:
-					verbosePrint("done writing imp settings.");
-					isWritingImp = false;
-					impWriteCounter = -1;
-					break;
-			}
-			timeOfLastImpWrite = millis();
-			impWriteCounter++;
-		}
-	}
-
-	public void createChannelSettingButtons(){
-		//the size and space of these buttons are dependendant on the size of the screen and full ChannelController
-		
-		verbosePrint("ChannelController: createChannelSettingButtons: creating channel setting buttons...");
-		int buttonW = 0;
-		int buttonX = 0;
-		int buttonH = 0;
-		int buttonY = 0; //variables to be used for button creation below
-		String buttonString = "";
-		Button tempButton;
-
-		//create all activate/deactivate buttons (left-most button in widget left of EEG graph). These buttons are always visible
-		for(int i = 0; i < nchan; i++){
-			buttonW = int((w1 - (spacer1 *4)) / 3);
-			buttonX = int(x1 + (spacer1));
-			// buttonH = int((h1 / (nchan + 1)) - (spacer1/2));
-			buttonH = buttonW;
-			buttonY = int(y1 + ((h1/(nchan+1))*(i+1)) - (buttonH/2));
-			buttonString = str(i+1);
-			tempButton = new Button (buttonX, buttonY, buttonW, buttonH, buttonString, 14);
-			channelSettingButtons[i][0] = tempButton;
-		}
-		//create all (P)ositive impedance check butttons ... these are the buttons just to the right of activate/deactivate buttons ... These are also always visible
-		//create all (N)egative impedance check butttons ... these are the buttons just to the right of activate/deactivate buttons ... These are also always visible
-
-		int downSizer = 6;
-		for(int i = 0; i < nchan; i++){
-			for(int j = 1; j < 3; j++){
-				buttonW = int(((w1 - (spacer1 *4)) / 3) - downSizer);
-				buttonX = int((x1 + j*(buttonW+6) + (j+1)*(spacer1)) + (downSizer/2) + 1);
-				// buttonH = int((h2 / (nchan + 1)) - (spacer2/2));
-				buttonY = int((y1 + (((h1-1)/(nchan+1))*(i+1)) - (buttonH/2)) + (downSizer/2) + 1);
-				buttonString = "";
-				tempButton = new Button (buttonX, buttonY, buttonW, buttonW, buttonString, 14);
-				impedanceCheckButtons[i][j-1] = tempButton;
-			}
-		}	
-
-		//create all other channel setting buttons... these are only visible when the user toggles to "showFullController = true"
-		for(int i = 0; i < nchan; i++){
-			for(int j = 1; j < 6; j++){
-				buttonW = int((w2 - (spacer2*6)) / 5);
-				buttonX = int((x2 + (spacer2 * (j))) + ((j-1) * buttonW));
-				// buttonH = int((h2 / (nchan + 1)) - (spacer2/2));
-				buttonY = int(y2 + (((h2-1)/(nchan+1))*(i+1)) - (buttonH/2));
-				buttonString = "N/A";
-				tempButton = new Button (buttonX, buttonY, buttonW, buttonH, buttonString, 14);
-				channelSettingButtons[i][j] = tempButton;
-			}
-		}
-	}
+  public float x1, y1, w1, h1, x2, y2, w2, h2; //all 1 values refer to the left panel that is always visible ... al 2 values refer to the right panel that is only visible when showFullController = true
+  public int montage_w, montage_h;
+  public int rowHeight;
+  public int buttonSpacing;
+  boolean showFullController = false;
+  boolean[] drawImpedanceValues = new boolean [nchan];
+
+  int spacer1 = 3;
+  int spacer2 = 5; //space between buttons
+
+  // [Number of Channels] x 6 array of buttons for channel settings
+  Button[][] channelSettingButtons = new Button [nchan][numSettingsPerChannel];  // [channel#][Button#]
+  // char[][] channelSettingValues = new char [nchan][numSettingsPerChannel]; // [channel#][Button#-value] ... this will incfluence text of button
+
+  //buttons just to the left of 
+  Button[][] impedanceCheckButtons = new Button [nchan][2];
+  // char [][] impedanceCheckValues = new char [nchan][2];
+
+  // Array for storing SRB2 history settings of channels prior to shutting off .. so you can return to previous state when reactivating channel
+  char[] previousSRB2 = new char [nchan];
+  // Array for storing SRB2 history settings of channels prior to shutting off .. so you can return to previous state when reactivating channel
+  char[] previousBIAS = new char [nchan];
+
+  //maximum different values for the different settings (Power Down, Gain, Input Type, BIAS, SRB2, SRB1) of 
+  //refer to page 44 of ADS1299 Datasheet: http://www.ti.com/lit/ds/symlink/ads1299.pdf
+  char[] maxValuesPerSetting = {
+    '1', // Power Down :: (0)ON, (1)OFF
+    '6', // Gain :: (0) x1, (1) x2, (2) x4, (3) x6, (4) x8, (5) x12, (6) x24 ... default
+    '7', // Channel Input :: (0)Normal Electrode Input, (1)Input Shorted, (2)Used in conjunction with BIAS_MEAS, (3)MVDD for supply measurement, (4)Temperature Sensor, (5)Test Signal, (6)BIAS_DRP ... positive electrode is driver, (7)BIAS_DRN ... negative electrode is driver
+    '1', // BIAS :: (0) Yes, (1) No
+    '1', // SRB2 :: (0) Open, (1) Closed
+    '1'
+  }; // SRB1 :: (0) Yes, (1) No ... this setting affects all channels ... either all on or all off
+
+  //variables used for channel write timing in writeChannelSettings()
+  long timeOfLastChannelWrite = 0;
+  int channelToWrite = -1;
+  int channelWriteCounter = 0;
+  boolean isWritingChannel = false;
+
+  //variables use for imp write timing with writeImpedanceSettings()
+  long timeOfLastImpWrite = 0;
+  int impChannelToWrite = -1;
+  int impWriteCounter = 0;
+  boolean isWritingImp = false;
+
+  boolean rewriteChannelWhenDoneWriting = false;
+  int channelToWriteWhenDoneWriting = 0;
+
+  boolean rewriteImpedanceWhenDoneWriting = false;
+  int impChannelToWriteWhenDoneWriting = 0;
+  char final_pORn = '0';
+  char final_onORoff = '0';
+
+  ChannelController(float _xPos, float _yPos, float _width, float _height, float _montage_w, float _montage_h) {
+    //positioning values for left panel (that is always visible)
+    x1 = _xPos;
+    y1 = _yPos;
+    w1 = _width;
+    h1 = _height;
+
+    //positioning values for right panel that is only visible when showFullController = true (behind the graph)
+    x2 = x1 + w1;
+    // x2 = gui.showMontageButton.but_x;
+    y2 = y1;
+    w2 = _montage_w;
+    h2 = h1;
+
+    createChannelSettingButtons();
+
+    // set on/off buttons to default channel colors
+    for (int i = 0; i < nchan; i++) {
+      channelSettingButtons[i][0].setColorNotPressed(channelColors[i%8]);
+    }
+  }
+
+  public void loadDefaultChannelSettings() {
+    verbosePrint("ChannelController: loading default channel settings to GUI's channel controller...");
+    for (int i = 0; i < nchan; i++) {
+      verbosePrint("chan: " + i + " ");
+      for (int j = 0; j < numSettingsPerChannel; j++) { //channel setting values
+        channelSettingValues[i][j] = char(openBCI.defaultChannelSettings.toCharArray()[j]); //parse defaultChannelSettings string created in the OpenBCI_ADS1299 class
+        if (j == numSettingsPerChannel - 1) {
+          println(char(openBCI.defaultChannelSettings.toCharArray()[j]));
+        } else {
+          print(char(openBCI.defaultChannelSettings.toCharArray()[j]) + ",");
+        }
+      }
+      for (int k = 0; k < 2; k++) { //impedance setting values
+        impedanceCheckValues[i][k] = '0';
+      }
+    }
+    verbosePrint("made it!");
+    update(); //update 1 time to refresh button values based on new loaded settings
+  }
+
+  public void update() {
+
+    //make false to check again below
+    for (int i = 0; i < nchan; i++) {
+      drawImpedanceValues[i] = false;
+    }
+
+    for (int i = 0; i < nchan; i++) { //for every channel
+      //update buttons based on channelSettingValues[i][j]
+      for (int j = 0; j < numSettingsPerChannel; j++) {		
+        switch(j) {  //what setting are we looking at
+        case 0: //on/off ??
+          if (channelSettingValues[i][j] == '0') channelSettingButtons[i][0].setColorNotPressed(channelColors[i%8]);// power down == false, set color to vibrant
+          if (channelSettingValues[i][j] == '1') channelSettingButtons[i][0].setColorNotPressed(color(75)); // channelSettingButtons[i][0].setString("B"); // power down == true, set color to dark gray, indicating power down
+          break;
+        case 1: //GAIN ??
+          if (channelSettingValues[i][j] == '0') channelSettingButtons[i][1].setString("x1");
+          if (channelSettingValues[i][j] == '1') channelSettingButtons[i][1].setString("x2");
+          if (channelSettingValues[i][j] == '2') channelSettingButtons[i][1].setString("x4");
+          if (channelSettingValues[i][j] == '3') channelSettingButtons[i][1].setString("x6");
+          if (channelSettingValues[i][j] == '4') channelSettingButtons[i][1].setString("x8");
+          if (channelSettingValues[i][j] == '5') channelSettingButtons[i][1].setString("x12");
+          if (channelSettingValues[i][j] == '6') channelSettingButtons[i][1].setString("x24");
+          break;
+        case 2: //input type ??
+          if (channelSettingValues[i][j] == '0') channelSettingButtons[i][2].setString("Normal");
+          if (channelSettingValues[i][j] == '1') channelSettingButtons[i][2].setString("Shorted");
+          if (channelSettingValues[i][j] == '2') channelSettingButtons[i][2].setString("BIAS_MEAS");
+          if (channelSettingValues[i][j] == '3') channelSettingButtons[i][2].setString("MVDD");
+          if (channelSettingValues[i][j] == '4') channelSettingButtons[i][2].setString("Temp.");
+          if (channelSettingValues[i][j] == '5') channelSettingButtons[i][2].setString("Test");
+          if (channelSettingValues[i][j] == '6') channelSettingButtons[i][2].setString("BIAS_DRP");
+          if (channelSettingValues[i][j] == '7') channelSettingButtons[i][2].setString("BIAS_DRN");
+          break;
+        case 3: //BIAS ??
+          if (channelSettingValues[i][j] == '0') channelSettingButtons[i][3].setString("Don't Include");
+          if (channelSettingValues[i][j] == '1') channelSettingButtons[i][3].setString("Include");
+          break;
+        case 4: // SRB2 ??
+          if (channelSettingValues[i][j] == '0') channelSettingButtons[i][4].setString("Off");
+          if (channelSettingValues[i][j] == '1') channelSettingButtons[i][4].setString("On");
+          break;
+        case 5: // SRB1 ??
+          if (channelSettingValues[i][j] == '0') channelSettingButtons[i][5].setString("No");
+          if (channelSettingValues[i][j] == '1') channelSettingButtons[i][5].setString("Yes");
+          break;
+        }
+      }
+
+      for (int k = 0; k < 2; k++) {
+        switch(k) {
+        case 0: // P Imp Buttons
+          if (impedanceCheckValues[i][k] == '0') {
+            impedanceCheckButtons[i][0].setColorNotPressed(color(75));
+            impedanceCheckButtons[i][0].setString("");
+          }
+          if (impedanceCheckValues[i][k] == '1') {
+            impedanceCheckButtons[i][0].setColorNotPressed(greenColor);
+            impedanceCheckButtons[i][0].setString("");
+            if (showFullController) {
+              drawImpedanceValues[i] = false;
+            } else {
+              drawImpedanceValues[i] = true;
+            }
+          }
+          break;
+        case 1: // N Imp Buttons
+          if (impedanceCheckValues[i][k] == '0') {
+            impedanceCheckButtons[i][1].setColorNotPressed(color(75));
+            impedanceCheckButtons[i][1].setString("");
+          }
+          if (impedanceCheckValues[i][k] == '1') {
+            impedanceCheckButtons[i][1].setColorNotPressed(greenColor);
+            impedanceCheckButtons[i][1].setString("");
+            if (showFullController) {
+              drawImpedanceValues[i] = false;
+            } else {
+              drawImpedanceValues[i] = true;
+            }
+          }
+          break;
+        }
+      }
+    }
+    //then reset to 1
+
+    //
+    if (isWritingChannel) {
+      writeChannelSettings(channelToWrite);
+    }
+
+    if (rewriteChannelWhenDoneWriting == true && isWritingChannel == false) {
+      initChannelWrite(channelToWriteWhenDoneWriting);
+      rewriteChannelWhenDoneWriting = false;
+    }
+
+    if (isWritingImp) {
+      writeImpedanceSettings(impChannelToWrite);
+    }
+
+    if (rewriteImpedanceWhenDoneWriting == true && isWritingImp == false) {
+      initImpWrite(impChannelToWriteWhenDoneWriting, final_pORn, final_onORoff);
+      rewriteImpedanceWhenDoneWriting = false;
+    }
+  }
+
+  public void draw() {
+
+    pushStyle();
+    noStroke();
+
+    //draw phantom rectangle to cover up random crap from Graph2D... we are replacing this stuff with the Montage Controller
+    fill(bgColor);
+    rect(x1 - 2, y1-(height*0.01f), w1, h1+(height*0.02f));
+
+    //draw light green rect behind pane title
+    fill(216, 233, 171);
+    rect(x2-2, y2-25, w2+1, 25);
+
+    //BG of montage controller (for debugging mainly)
+    // fill(255,255,255,123);
+    // rect(x1, y1 - 1, w1, h1);
+
+    //draw background pane of impedance buttons
+    fill(221);
+    rect(x1 + w1/3 + 1, y1, 2*(w1/3) - 3, h1 - 2);
+
+    //draw slightly darker line guides/separators for impedance buttons
+    stroke(175);
+    strokeWeight(2);
+    for (int i = 0; i < nchan; i++) {
+      line(x1 + w1/3 + 2, y1 + (((h1-1)/(nchan+1))*(i+1)), x2 - 3, y1 + (((h1-1)/(nchan+1))*(i+1)));
+    }
+    line(x1 + 2*(w1/3) - 1, y1 + 1, x1 + 2*(w1/3) - 1, y1 + (h1-1) - 1);
+    strokeWeight(0);
+
+    //channel buttons
+    for (int i = 0; i < nchan; i++) {
+      channelSettingButtons[i][0].draw(); //draw on/off channel buttons
+      //draw impedance buttons
+      for (int j = 0; j < 2; j++) {
+        impedanceCheckButtons[i][j].draw();
+      }
+    }
+
+    //label impedance button columns
+    fill(bgColor);
+    text("P", x1 + 1*(w1/2), y1 + 12);
+    text("N", x1 + 5*(w1/6) - 2, y1 + 12);
+
+    if (showFullController) {
+      //background
+      noStroke();
+      fill(0, 0, 0, 100);
+      rect(x1 + w1, y1, w2, h2);
+
+      // [numChan] x 5 ... all channel setting buttons (other than on/off) 
+      for (int i = 0; i < nchan; i++) {
+        for (int j = 1; j < 6; j++) {
+          // println("drawing button " + i + "," + j);
+          // println("Button: " + channelSettingButtons[i][j]);
+          channelSettingButtons[i][j].draw();
+        }
+      }
+
+      //draw column headers for channel settings behind EEG graph
+      fill(bgColor);
+      text("PGA Gain", x2 + (w2/10)*1, y1 - 12);
+      text("Input Type", x2 + (w2/10)*3, y1 - 12);
+      text("  Bias ", x2 + (w2/10)*5, y1 - 12);
+      text("SRB2", x2 + (w2/10)*7, y1 - 12);
+      text("SRB1", x2 + (w2/10)*9, y1 - 12);
+
+      //if mode is not from OpenBCI, draw a dark overlay to indicate that you cannot edit these settings
+      if (eegDataSource != DATASOURCE_NORMAL && eegDataSource != DATASOURCE_NORMAL_W_AUX) {
+        fill(0, 0, 0, 200);
+        noStroke();
+        rect(x2-2, y2, w2+1, h2);
+        fill(255);
+        textSize(24);
+        text("DATA SOURCE (LIVE) only", x2 + (w2/2), y2 + (h2/2));
+      }
+    }
+
+    if ((eegDataSource != DATASOURCE_NORMAL) && (eegDataSource != DATASOURCE_NORMAL_W_AUX)) {
+      fill(0, 0, 0, 200);
+      rect(x1 + w1/3 + 1, y1, 2*(w1/3) - 3, h1 - 2);
+    }
+
+    for (int i = 0; i < nchan; i++) {
+      if (drawImpedanceValues[i] == true) {
+        gui.impValuesMontage[i].draw();  //impedance values on montage plot
+      }
+    }
+
+    popStyle();
+  }
+
+  public void mousePressed() {
+    //if fullChannelController and one of the buttons (other than ON/OFF) is clicked
+
+      //if dataSource is coming from OpenBCI, allow user to interact with channel controller
+    if ( (eegDataSource == DATASOURCE_NORMAL) || (eegDataSource == DATASOURCE_NORMAL_W_AUX) ) {
+      if (showFullController) {
+        for (int i = 0; i < nchan; i++) { //When [i][j] button is clicked
+          for (int j = 1; j < numSettingsPerChannel; j++) {		
+            if (channelSettingButtons[i][j].isMouseHere()) {
+              //increment [i][j] channelSettingValue by, until it reaches max values per setting [j], 
+              channelSettingButtons[i][j].wasPressed = true;
+              channelSettingButtons[i][j].isActive = true;
+            }
+          }
+        }
+      }
+    }
+    //on/off button and Imp buttons can always be clicked/released
+    for (int i = 0; i < nchan; i++) {
+      if (channelSettingButtons[i][0].isMouseHere()) {
+        channelSettingButtons[i][0].wasPressed = true;
+        channelSettingButtons[i][0].isActive = true;
+      }
+
+      //only allow editing of impedance if dataSource == from OpenBCI
+      if ((eegDataSource == DATASOURCE_NORMAL) || (eegDataSource == DATASOURCE_NORMAL_W_AUX)) {
+        if (impedanceCheckButtons[i][0].isMouseHere()) {
+          impedanceCheckButtons[i][0].wasPressed = true;
+          impedanceCheckButtons[i][0].isActive = true;
+        }
+        if (impedanceCheckButtons[i][1].isMouseHere()) {
+          impedanceCheckButtons[i][1].wasPressed = true;
+          impedanceCheckButtons[i][1].isActive = true;
+        }
+      }
+    }
+  }
+
+  public void mouseReleased() {
+    //if fullChannelController and one of the buttons (other than ON/OFF) is released
+    if (showFullController) {
+      for (int i = 0; i < nchan; i++) { //When [i][j] button is clicked
+        for (int j = 1; j < numSettingsPerChannel; j++) {		
+          if (channelSettingButtons[i][j].isMouseHere() && channelSettingButtons[i][j].wasPressed == true) {
+            if (channelSettingValues[i][j] < maxValuesPerSetting[j]) {
+              channelSettingValues[i][j]++;	//increment [i][j] channelSettingValue by, until it reaches max values per setting [j],
+            } else {
+              channelSettingValues[i][j] = '0';
+            }	
+            // if you're not currently writing a channel and not waiting to rewrite after you've finished mashing the button
+            if (!isWritingChannel && rewriteChannelWhenDoneWriting == false) {
+              initChannelWrite(i);//write new ADS1299 channel row values to OpenBCI
+            } else { //else wait until a the current write has finished and then write again ... this is to not overwrite the wrong values while writing a channel
+              verbosePrint("CONGRATULATIONS, YOU'RE MASHING BUTTONS!");
+              rewriteChannelWhenDoneWriting = true;
+              channelToWriteWhenDoneWriting = i;
+            }
+          }
+
+          // if(!channelSettingButtons[i][j].isMouseHere()){
+          channelSettingButtons[i][j].isActive = false;
+          channelSettingButtons[i][j].wasPressed = false;
+          // }
+        }
+      }
+    }
+    //ON/OFF button can always be clicked/released
+    for (int i = 0; i < nchan; i++) {
+      //was on/off clicked?
+      if (channelSettingButtons[i][0].isMouseHere() && channelSettingButtons[i][0].wasPressed == true) {
+        if (channelSettingValues[i][0] < maxValuesPerSetting[0]) {
+          channelSettingValues[i][0] = '1';	//increment [i][j] channelSettingValue by, until it reaches max values per setting [j], 
+          // channelSettingButtons[i][0].setColorNotPressed(color(25,25,25));
+          // powerDownChannel(i);
+          deactivateChannel(i);
+        } else {
+          channelSettingValues[i][0] = '0';
+          // channelSettingButtons[i][0].setColorNotPressed(color(255));
+          // powerUpChannel(i);
+          activateChannel(i);
+        }
+        // writeChannelSettings(i);//write new ADS1299 channel row values to OpenBCI
+      }
+
+      //was P imp check button clicked?
+      if (impedanceCheckButtons[i][0].isMouseHere() && impedanceCheckButtons[i][0].wasPressed == true) {
+        if (impedanceCheckValues[i][0] < '1') {
+          // impedanceCheckValues[i][0] = '1';	//increment [i][j] channelSettingValue by, until it reaches max values per setting [j], 
+          // channelSettingButtons[i][0].setColorNotPressed(color(25,25,25));
+          // writeImpedanceSettings(i);
+          initImpWrite(i, 'p', '1');
+          //initImpWrite
+          verbosePrint("a");
+        } else {
+          // impedanceCheckValues[i][0] = '0';
+          // channelSettingButtons[i][0].setColorNotPressed(color(255));
+          // writeImpedanceSettings(i);
+          initImpWrite(i, 'p', '0');
+          verbosePrint("b");
+        }
+        // writeChannelSettings(i);//write new ADS1299 channel row values to OpenBCI
+      }
+
+      //was N imp check button clicked?
+      if (impedanceCheckButtons[i][1].isMouseHere() && impedanceCheckButtons[i][1].wasPressed == true) {
+        if (impedanceCheckValues[i][1] < '1') {
+          initImpWrite(i, 'n', '1');
+          //initImpWrite
+          verbosePrint("c");
+        } else {
+          initImpWrite(i, 'n', '0');
+          verbosePrint("d");
+        }
+        // writeChannelSettings(i);//write new ADS1299 channel row values to OpenBCI
+      }
+
+      channelSettingButtons[i][0].isActive = false;
+      channelSettingButtons[i][0].wasPressed = false;
+      impedanceCheckButtons[i][0].isActive = false;
+      impedanceCheckButtons[i][0].wasPressed = false;
+      impedanceCheckButtons[i][1].isActive = false;
+      impedanceCheckButtons[i][1].wasPressed = false;
+    }
+
+    update(); //update once to refresh button values
+  }
+
+  public void fillValuesBasedOnDefault(byte _defaultValues) {
+    //interpret incoming HEX value (from OpenBCI) and pass into all default channelSettingValues
+    //dencode byte from OpenBCI and break it apart into the channelSettingValues[][] array
+  }
+
+  public void powerDownChannel(int _numChannel) {
+    verbosePrint("Powering down channel " + str(int(_numChannel) + int(1)));
+    //save SRB2 and BIAS settings in 2D history array (to turn back on when channel is reactivated)
+    previousBIAS[_numChannel] = channelSettingValues[_numChannel][3];
+    previousSRB2[_numChannel] = channelSettingValues[_numChannel][4];
+    channelSettingValues[_numChannel][3] = '0'; //make sure to disconnect from BIAS
+    channelSettingValues[_numChannel][4] = '0'; //make sure to disconnect from SRB2
+
+    // initChannelWrite(_numChannel);//writeChannelSettings
+    channelSettingValues[_numChannel][0] = '1'; //update powerUp/powerDown value of 2D array
+    //if(_numChannel < 8){
+    verbosePrint("Command: " + command_deactivate_channel[_numChannel]);
+    //openBCI.serial_openBCI.write(command_deactivate_channel[_numChannel]);
+    openBCI.deactivateChannel(_numChannel);  //assumes numChannel counts from zero (not one)...handles regular and daisy channels
+    //}else{ //if a daisy channel
+    //	verbosePrint("Command: " + command_deactivate_channel_daisy[_numChannel - 8]);
+    //	openBCI.serial_openBCI.write(command_deactivate_channel_daisy[_numChannel - 8]);
+    //}
+  }
+
+  public void powerUpChannel(int _numChannel) {
+    verbosePrint("Powering up channel " + str(int(_numChannel) + int(1)));
+    //replace SRB2 and BIAS settings with values from 2D history array
+    channelSettingValues[_numChannel][3] = previousBIAS[_numChannel];
+    channelSettingValues[_numChannel][4] = previousSRB2[_numChannel];
+
+    // initChannelWrite(_numChannel);//writeChannelSettings
+    channelSettingValues[_numChannel][0] = '0'; //update powerUp/powerDown value of 2D array
+    //if(_numChannel < 8){
+    verbosePrint("Command: " + command_activate_channel[_numChannel]);
+    //openBCI.serial_openBCI.write(command_activate_channel[_numChannel]);
+    openBCI.activateChannel(_numChannel);  //assumes numChannel counts from zero (not one)...handles regular and daisy channels//assumes numChannel counts from zero (not one)...handles regular and daisy channels
+    //} else{ //if a daisy channel
+    //	verbosePrint("Command: " + command_activate_channel_daisy[_numChannel - 8]);
+    //	openBCI.serial_openBCI.write(command_activate_channel_daisy[_numChannel - 8]);
+    //}
+  }
+
+  public void initChannelWrite(int _numChannel) {
+    //after clicking any button, write the new settings for that channel to OpenBCI
+    if (!isWritingImp) { //make sure you aren't currently writing imp settings for a channel
+      verbosePrint("Writing channel settings for channel " + str(_numChannel+1) + " to OpenBCI!");
+      timeOfLastChannelWrite = millis();
+      isWritingChannel = true;
+      channelToWrite = _numChannel;
+    }
+  }
+
+  public void initImpWrite(int _numChannel, char pORn, char onORoff) {
+    //after clicking any button, write the new settings for that channel to OpenBCI
+    if (!isWritingChannel) { //make sure you aren't currently writing imp settings for a channel
+      // if you're not currently writing a channel and not waiting to rewrite after you've finished mashing the button
+      if (!isWritingImp && rewriteImpedanceWhenDoneWriting == false) {
+        verbosePrint("Writing impedance check settings (" + pORn + "," + onORoff +  ") for channel " + str(_numChannel+1) + " to OpenBCI!");
+        if (pORn == 'p') {
+          impedanceCheckValues[_numChannel][0] = onORoff;
+        }
+        if (pORn == 'n') {
+          impedanceCheckValues[_numChannel][1] = onORoff;
+        }
+
+        timeOfLastImpWrite = millis();
+        isWritingImp = true;
+        impChannelToWrite = _numChannel;
+      } else { //else wait until a the current write has finished and then write again ... this is to not overwrite the wrong values while writing a channel
+        verbosePrint("CONGRATULATIONS, YOU'RE MASHING BUTTONS!");
+        rewriteImpedanceWhenDoneWriting = true;
+        impChannelToWriteWhenDoneWriting = _numChannel;
+
+        if (pORn == 'p') {
+          final_pORn = 'p';
+        }
+        if (pORn == 'n') {
+          final_pORn = 'n';
+        }
+        final_onORoff = onORoff;
+      }
+    }
+  }
+
+  public void writeChannelSettings(int _numChannel) {
+    if (millis() - timeOfLastChannelWrite >= 50) { //wait 50 milliseconds before sending next character
+      verbosePrint("---");
+      switch (channelWriteCounter) {
+      case 0: //start sequence by send 'x'
+        verbosePrint("x" + " :: " + millis());
+        openBCI.serial_openBCI.write('x');
+        break;
+      case 1: //send channel number
+        verbosePrint(str(_numChannel+1) + " :: " + millis());
+        if (_numChannel < 8) {
+          openBCI.serial_openBCI.write((char)('0'+(_numChannel+1)));
+        }
+        if (_numChannel >= 8) {
+          //openBCI.serial_openBCI.write((command_activate_channel_daisy[_numChannel-8]));
+          openBCI.serial_openBCI.write((command_activate_channel[_numChannel])); //command_activate_channel holds non-daisy and daisy
+        }
+        break;
+      case 2: 
+      case 3: 
+      case 4: 
+      case 5: 
+      case 6: 
+      case 7:
+        verbosePrint(channelSettingValues[_numChannel][channelWriteCounter-2] + " :: " + millis());
+        openBCI.serial_openBCI.write(channelSettingValues[_numChannel][channelWriteCounter-2]);
+        //value for ON/OF
+        break;
+      case 8:
+        verbosePrint("X" + " :: " + millis());
+        openBCI.serial_openBCI.write('X'); // send 'X' to end message sequence
+        break;
+      case 9:
+        verbosePrint("done writing channel.");
+        isWritingChannel = false;
+        channelWriteCounter = -1;
+        break;
+      }
+      timeOfLastChannelWrite = millis();
+      channelWriteCounter++;
+    }
+  }
+
+  public void writeImpedanceSettings(int _numChannel) {
+    //after clicking an impedance button, write the new impedance settings for that channel to OpenBCI
+    //after clicking any button, write the new settings for that channel to OpenBCI
+    // verbosePrint("Writing impedance settings for channel " + _numChannel + " to OpenBCI!");
+    //write setting 1, delay 5ms.. write setting 2, delay 5ms, etc.
+    if (millis() - timeOfLastImpWrite >= 50) { //wait 50 milliseconds before sending next character
+      verbosePrint("---");
+      switch (impWriteCounter) {
+      case 0: //start sequence by sending 'z'
+        verbosePrint("z" + " :: " + millis());
+        openBCI.serial_openBCI.write('z');
+        break;
+      case 1: //send channel number
+        verbosePrint(str(_numChannel+1) + " :: " + millis());
+        if (_numChannel < 8) {
+          openBCI.serial_openBCI.write((char)('0'+(_numChannel+1)));
+        }
+        if (_numChannel >= 8) {
+          //openBCI.serial_openBCI.write((command_activate_channel_daisy[_numChannel-8]));
+          openBCI.serial_openBCI.write((command_activate_channel[_numChannel])); //command_activate_channel holds non-daisy and daisy values
+        }
+        break;
+      case 2: 
+      case 3: 
+        verbosePrint(impedanceCheckValues[_numChannel][impWriteCounter-2] + " :: " + millis());
+        openBCI.serial_openBCI.write(impedanceCheckValues[_numChannel][impWriteCounter-2]);
+        //value for ON/OF
+        break;
+      case 4:
+        verbosePrint("Z" + " :: " + millis());
+        openBCI.serial_openBCI.write('Z'); // send 'X' to end message sequence
+        break;
+      case 5:
+        verbosePrint("done writing imp settings.");
+        isWritingImp = false;
+        impWriteCounter = -1;
+        break;
+      }
+      timeOfLastImpWrite = millis();
+      impWriteCounter++;
+    }
+  }
+
+  public void createChannelSettingButtons() {
+    //the size and space of these buttons are dependendant on the size of the screen and full ChannelController
+
+    verbosePrint("ChannelController: createChannelSettingButtons: creating channel setting buttons...");
+    int buttonW = 0;
+    int buttonX = 0;
+    int buttonH = 0;
+    int buttonY = 0; //variables to be used for button creation below
+    String buttonString = "";
+    Button tempButton;
+
+    //create all activate/deactivate buttons (left-most button in widget left of EEG graph). These buttons are always visible
+    for (int i = 0; i < nchan; i++) {
+      buttonW = int((w1 - (spacer1 *4)) / 3);
+      buttonX = int(x1 + (spacer1));
+      // buttonH = int((h1 / (nchan + 1)) - (spacer1/2));
+      buttonH = buttonW;
+      buttonY = int(y1 + ((h1/(nchan+1))*(i+1)) - (buttonH/2));
+      buttonString = str(i+1);
+      tempButton = new Button (buttonX, buttonY, buttonW, buttonH, buttonString, 14);
+      channelSettingButtons[i][0] = tempButton;
+    }
+    //create all (P)ositive impedance check butttons ... these are the buttons just to the right of activate/deactivate buttons ... These are also always visible
+    //create all (N)egative impedance check butttons ... these are the buttons just to the right of activate/deactivate buttons ... These are also always visible
+
+    int downSizer = 6;
+    for (int i = 0; i < nchan; i++) {
+      for (int j = 1; j < 3; j++) {
+        buttonW = int(((w1 - (spacer1 *4)) / 3) - downSizer);
+        buttonX = int((x1 + j*(buttonW+6) + (j+1)*(spacer1)) + (downSizer/2) + 1);
+        // buttonH = int((h2 / (nchan + 1)) - (spacer2/2));
+        buttonY = int((y1 + (((h1-1)/(nchan+1))*(i+1)) - (buttonH/2)) + (downSizer/2) + 1);
+        buttonString = "";
+        tempButton = new Button (buttonX, buttonY, buttonW, buttonW, buttonString, 14);
+        impedanceCheckButtons[i][j-1] = tempButton;
+      }
+    }	
+
+    //create all other channel setting buttons... these are only visible when the user toggles to "showFullController = true"
+    for (int i = 0; i < nchan; i++) {
+      for (int j = 1; j < 6; j++) {
+        buttonW = int((w2 - (spacer2*6)) / 5);
+        buttonX = int((x2 + (spacer2 * (j))) + ((j-1) * buttonW));
+        // buttonH = int((h2 / (nchan + 1)) - (spacer2/2));
+        buttonY = int(y2 + (((h2-1)/(nchan+1))*(i+1)) - (buttonH/2));
+        buttonString = "N/A";
+        tempButton = new Button (buttonX, buttonY, buttonW, buttonH, buttonString, 14);
+        channelSettingButtons[i][j] = tempButton;
+      }
+    }
+  }
 };
 

--- a/OpenBCI_GUI/ControlPanel.pde
+++ b/OpenBCI_GUI/ControlPanel.pde
@@ -20,10 +20,10 @@ import controlP5.*;
 
 ControlP5 cp5; //program-wide instance of ControlP5
 CallbackListener cb = new CallbackListener() { //used by ControlP5 to clear text field on double-click
-    public void controlEvent(CallbackEvent theEvent) {
-    	println("CallbackListener: controlEvent: clearing");
-    	cp5.get(Textfield.class,"fileName").clear();
-    }
+  public void controlEvent(CallbackEvent theEvent) {
+    println("CallbackListener: controlEvent: clearing");
+    cp5.get(Textfield.class, "fileName").clear();
+  }
 };
 
 MenuList sourceList;
@@ -36,8 +36,8 @@ MenuList sdTimes;
 
 color boxColor = color(200);
 // color boxStrokeColor = color(173,183,192);
-color boxStrokeColor = color(138,146,153);
-color greenColor = color(184,220,105);
+color boxStrokeColor = color(138, 146, 153);
+color greenColor = color(184, 220, 105);
 
 // Button openClosePort;
 // boolean portButtonPressed;
@@ -66,374 +66,364 @@ boolean selectSDFilePressed = false;
 
 class ControlPanel {
 
-	public int x, y, w, h;
-	public boolean isOpen;
+  public int x, y, w, h;
+  public boolean isOpen;
 
-	boolean showSourceBox, showSerialBox, showFileBox, showChannelBox, showInitBox;
-	PlotFontInfo fontInfo;
+  boolean showSourceBox, showSerialBox, showFileBox, showChannelBox, showInitBox;
+  PlotFontInfo fontInfo;
 
-	//various control panel elements that are unique to specific datasources
-	DataSourceBox dataSourceBox;
-	SerialBox serialBox;
-	DataLogBox dataLogBox;
-	ChannelCountBox channelCountBox;
-	InitBox initBox;
+  //various control panel elements that are unique to specific datasources
+  DataSourceBox dataSourceBox;
+  SerialBox serialBox;
+  DataLogBox dataLogBox;
+  ChannelCountBox channelCountBox;
+  InitBox initBox;
 
-	PlaybackFileBox playbackFileBox;
-	SDConverterBox sdConverterBox;
+  PlaybackFileBox playbackFileBox;
+  SDConverterBox sdConverterBox;
 
-	SDBox sdBox;
+  SDBox sdBox;
 
-	boolean drawStopInstructions;
+  boolean drawStopInstructions;
 
-	int globalPadding; //design feature: passed through to all box classes as the global spacing .. in pixels .. for all elements/subelements
-	int globalBorder;
+  int globalPadding; //design feature: passed through to all box classes as the global spacing .. in pixels .. for all elements/subelements
+  int globalBorder;
 
-	boolean convertingSD = false;
+  boolean convertingSD = false;
 
-	ControlPanel(OpenBCI_GUI mainClass){
+  ControlPanel(OpenBCI_GUI mainClass) {
 
-		x = 2;
-		y = 2 + controlPanelCollapser.but_dy;		
-		w = controlPanelCollapser.but_dx;
-		h = height - int(helpWidget.h);
+    x = 2;
+    y = 2 + controlPanelCollapser.but_dy;		
+    w = controlPanelCollapser.but_dx;
+    h = height - int(helpWidget.h);
 
-		isOpen = true;
+    isOpen = true;
 
-		fontInfo = new PlotFontInfo();
+    fontInfo = new PlotFontInfo();
 
-		// f1 = createFont("Raleway-SemiBold.otf", 16);
-		// f2 = createFont("Raleway-Regular.otf", 15);
-		// f3 = createFont("Raleway-SemiBold.otf", 15);
+    // f1 = createFont("Raleway-SemiBold.otf", 16);
+    // f2 = createFont("Raleway-Regular.otf", 15);
+    // f3 = createFont("Raleway-SemiBold.otf", 15);
 
-		globalPadding = 10;  //controls the padding of all elements on the control panel
-		globalBorder = 0;   //controls the border of all elements in the control panel ... using processing's stroke() instead
+    globalPadding = 10;  //controls the padding of all elements on the control panel
+    globalBorder = 0;   //controls the border of all elements in the control panel ... using processing's stroke() instead
 
-		cp5 = new ControlP5(mainClass); 
+    cp5 = new ControlP5(mainClass); 
 
-		//boxes active when eegDataSource = Normal (OpenBCI) 
-		dataSourceBox = new DataSourceBox(x, y, w, h, globalPadding);
-		serialBox = new SerialBox(x + w, dataSourceBox.y, w, h, globalPadding);
-		dataLogBox = new DataLogBox(x + w, (serialBox.y + serialBox.h), w, h, globalPadding);
-		channelCountBox = new ChannelCountBox(x + w, (dataLogBox.y + dataLogBox.h), w, h, globalPadding);
-		sdBox = new SDBox(x + w, (channelCountBox.y + channelCountBox.h), w, h, globalPadding);
+    //boxes active when eegDataSource = Normal (OpenBCI) 
+    dataSourceBox = new DataSourceBox(x, y, w, h, globalPadding);
+    serialBox = new SerialBox(x + w, dataSourceBox.y, w, h, globalPadding);
+    dataLogBox = new DataLogBox(x + w, (serialBox.y + serialBox.h), w, h, globalPadding);
+    channelCountBox = new ChannelCountBox(x + w, (dataLogBox.y + dataLogBox.h), w, h, globalPadding);
+    sdBox = new SDBox(x + w, (channelCountBox.y + channelCountBox.h), w, h, globalPadding);
 
-		//boxes active when eegDataSource = Playback
-		playbackFileBox = new PlaybackFileBox(x + w, dataSourceBox.y, w, h, globalPadding);
-		sdConverterBox = new SDConverterBox(x + w, (playbackFileBox.y + playbackFileBox.h), w, h, globalPadding);
+    //boxes active when eegDataSource = Playback
+    playbackFileBox = new PlaybackFileBox(x + w, dataSourceBox.y, w, h, globalPadding);
+    sdConverterBox = new SDConverterBox(x + w, (playbackFileBox.y + playbackFileBox.h), w, h, globalPadding);
 
-		initBox = new InitBox(x, (dataSourceBox.y + dataSourceBox.h), w, h, globalPadding);
+    initBox = new InitBox(x, (dataSourceBox.y + dataSourceBox.h), w, h, globalPadding);
+  }
 
+  public void update() {
+    //toggle view of cp5 / serial list selection table
+    if (isOpen) { // if control panel is open
+      if (!cp5.isVisible()) {  //and cp5 is not visible
+        cp5.show(); // shot it
+      }
+    } else { //the opposite of above
+      if (cp5.isVisible()) {
+        cp5.hide();
+      }
+    }
 
-	}
+    //update all boxes if they need to be
+    dataSourceBox.update();
+    serialBox.update();
+    dataLogBox.update();
+    channelCountBox.update();
+    sdBox.update();
+    initBox.update();
 
-	public void update(){
-		//toggle view of cp5 / serial list selection table
-		if(isOpen){ // if control panel is open
-			if(!cp5.isVisible()){  //and cp5 is not visible
-				cp5.show(); // shot it
-			}
-		}
-		else{ //the opposite of above
-			if(cp5.isVisible()){
-				cp5.hide();
-			}
-		}
+    serialList.updateMenu();
 
-		//update all boxes if they need to be
-		dataSourceBox.update();
-		serialBox.update();
-		dataLogBox.update();
-		channelCountBox.update();
-		sdBox.update();
-		initBox.update();
+    //SD File Conversion
+    while (convertingSD == true) {
+      convertSDFile();
+    }
+  }
 
-		serialList.updateMenu();
+  public void draw() {
 
-		//SD File Conversion
-		while(convertingSD == true){
-			convertSDFile();
-		}
+    pushStyle();
+    noStroke();
 
-	}
+    //dark overlay of rest of interface to indicate it's not clickable
+    fill(0, 0, 0, 185);
+    rect(0, 0, width, height);
 
-	public void draw(){
+    pushStyle();
+    fill(255);
+    noStroke();
+    rect(0, 0, width, 32);
+    popStyle();
 
-		pushStyle();
-		noStroke();
+    // //background pane of control panel
+    // fill(35,35,35);
+    // rect(0,0,w,h);
 
-		//dark overlay of rest of interface to indicate it's not clickable
-		fill(0,0,0,185);
-		rect(0,0,width,height);
+    popStyle();
 
-		pushStyle();
-			fill(255);
-			noStroke();
-			rect(0, 0, width, 32);
-		popStyle();
+    initBox.draw();
 
-		// //background pane of control panel
-		// fill(35,35,35);
-		// rect(0,0,w,h);
+    if (systemMode == 10) {
+      drawStopInstructions = true;
+    }
 
-		popStyle();
+    if (systemMode != 10) { // only draw control panel boxes if system running is false
+      dataSourceBox.draw();
+      drawStopInstructions = false;
+      cp5.setVisible(true);//make sure controlP5 elements are visible
+      if (eegDataSource == 0) {	//when data source is from OpenBCI
+        serialBox.draw();
+        dataLogBox.draw();
+        channelCountBox.draw();
+        sdBox.draw();
+        cp5.get(Textfield.class, "fileName").setVisible(true); //make sure the data file field is visible
+        cp5.get(MenuList.class, "serialList").setVisible(true); //make sure the serialList menulist is visible
+        cp5.get(MenuList.class, "sdTimes").setVisible(true); //make sure the SD time record options menulist is visible
+        //make sure serial list is visible
+        //set other CP5 controllers invisible
+      } else if (eegDataSource == 1) { //when data source is from playback file
+        playbackFileBox.draw();
+        sdConverterBox.draw();
+        //set other CP5 controllers invisible
+        cp5.get(Textfield.class, "fileName").setVisible(false); //make sure the data file field is visible
+        cp5.get(MenuList.class, "serialList").setVisible(false);
+        cp5.get(MenuList.class, "sdTimes").setVisible(false);
+      } else if (eegDataSource == 2) {
+        //make sure serial list is visible
+        //set other CP5 controllers invisible
+        cp5.get(Textfield.class, "fileName").setVisible(false); //make sure the data file field is visible
+        cp5.get(MenuList.class, "serialList").setVisible(false);
+        cp5.get(MenuList.class, "sdTimes").setVisible(false);
+      } else {
+        //set other CP5 controllers invisible
+        cp5.get(Textfield.class, "fileName").setVisible(false); //make sure the data file field is visible
+        cp5.get(MenuList.class, "serialList").setVisible(false);
+        cp5.get(MenuList.class, "sdTimes").setVisible(false);
+      }
+    } else {
+      cp5.setVisible(false); // if isRunning is true, hide all controlP5 elements
+    }
 
-		initBox.draw();
+    //draw the box that tells you to stop the system in order to edit control settings
+    if (drawStopInstructions) {
+      pushStyle();
+      fill(boxColor);
+      strokeWeight(1);
+      stroke(boxStrokeColor);
+      rect(x, y, w, dataSourceBox.h); //draw background of box
+      String stopInstructions = "Press the \"STOP SYSTEM\" button to edit system settings.";
+      textAlign(CENTER, TOP);
+      textFont(f2);
+      fill(bgColor);
+      text(stopInstructions, x + globalPadding*2, y + globalPadding*4, w - globalPadding*4, dataSourceBox.h - globalPadding*4);
+      popStyle();
+    }
+  }
 
-		if(systemMode == 10){
-			drawStopInstructions = true;
-		}
+  //mouse pressed in control panel
+  public void CPmousePressed() {
+    verbosePrint("CPmousePressed");
 
-		if(systemMode != 10){ // only draw control panel boxes if system running is false
-			dataSourceBox.draw();
-			drawStopInstructions = false;
-			cp5.setVisible(true);//make sure controlP5 elements are visible
-			if(eegDataSource == 0){	//when data source is from OpenBCI
-				serialBox.draw();
-				dataLogBox.draw();
-				channelCountBox.draw();
-				sdBox.draw();
-				cp5.get(Textfield.class,"fileName").setVisible(true); //make sure the data file field is visible
-				cp5.get(MenuList.class,"serialList").setVisible(true); //make sure the serialList menulist is visible
-				cp5.get(MenuList.class,"sdTimes").setVisible(true); //make sure the SD time record options menulist is visible
-				//make sure serial list is visible
-				//set other CP5 controllers invisible
-			} else if(eegDataSource == 1){ //when data source is from playback file
-				playbackFileBox.draw();
-				sdConverterBox.draw();
-				//set other CP5 controllers invisible
-				cp5.get(Textfield.class,"fileName").setVisible(false); //make sure the data file field is visible
-				cp5.get(MenuList.class,"serialList").setVisible(false);
-				cp5.get(MenuList.class,"sdTimes").setVisible(false);
-			} else if(eegDataSource == 2){
-				//make sure serial list is visible
-				//set other CP5 controllers invisible
-				cp5.get(Textfield.class,"fileName").setVisible(false); //make sure the data file field is visible
-				cp5.get(MenuList.class,"serialList").setVisible(false);
-				cp5.get(MenuList.class,"sdTimes").setVisible(false);
-			} else {
-				//set other CP5 controllers invisible
-				cp5.get(Textfield.class,"fileName").setVisible(false); //make sure the data file field is visible
-				cp5.get(MenuList.class,"serialList").setVisible(false);
-				cp5.get(MenuList.class,"sdTimes").setVisible(false);
-			}
-		} else {
-			cp5.setVisible(false); // if isRunning is true, hide all controlP5 elements
-		}
+    if (initSystemButton.isMouseHere()) {
+      initSystemButton.setIsActive(true);
+      initButtonPressed = true;
+    }
 
-		//draw the box that tells you to stop the system in order to edit control settings
-		if(drawStopInstructions){
-			pushStyle();
-				fill(boxColor);
-				strokeWeight(1);
-				stroke(boxStrokeColor);
-				rect(x, y, w, dataSourceBox.h); //draw background of box
-				String stopInstructions = "Press the \"STOP SYSTEM\" button to edit system settings.";
-				textAlign(CENTER, TOP);
-				textFont(f2);
-				fill(bgColor);
-				text(stopInstructions, x + globalPadding*2, y + globalPadding*4, w - globalPadding*4, dataSourceBox.h - globalPadding*4);
-			popStyle();
-		}
-	}
+    //only able to click buttons of control panel when system is not running
+    if (systemMode != 10) {
+      //active buttons during DATASOURCE_NORMAL
+      if (eegDataSource == 0) {
+        if (refreshPort.isMouseHere()) {
+          refreshPort.setIsActive(true);
+          refreshButtonPressed = true;
+        }
 
-	//mouse pressed in control panel
-	public void CPmousePressed(){
-		verbosePrint("CPmousePressed");
+        if (autoFileName.isMouseHere()) {
+          autoFileName.setIsActive(true);
+          fileButtonPressed = true;
+        }
 
-		if(initSystemButton.isMouseHere()){
-			initSystemButton.setIsActive(true);
-			initButtonPressed = true;
-		}
+        if (chanButton8.isMouseHere()) {
+          chanButton8.setIsActive(true);
+          chanButton8Pressed = true;
+          chanButton8.color_notPressed = color(184, 220, 105);
+          chanButton16.color_notPressed = color(255);
+        }
 
-		//only able to click buttons of control panel when system is not running
-		if(systemMode != 10){
-			//active buttons during DATASOURCE_NORMAL
-			if(eegDataSource == 0){
-				if(refreshPort.isMouseHere()){
-					refreshPort.setIsActive(true);
-					refreshButtonPressed = true;
-				}
+        if (chanButton16.isMouseHere()) {
+          chanButton16.setIsActive(true);
+          chanButton16Pressed = true;
+          chanButton8.color_notPressed = color(255);
+          chanButton16.color_notPressed = color(184, 220, 105);
+        }
+      }
 
-				if(autoFileName.isMouseHere()){
-					autoFileName.setIsActive(true);
-					fileButtonPressed = true;
-				}
+      //active buttons during DATASOURCE_PLAYBACKFILE
+      if (eegDataSource == 1) {
+        if (selectPlaybackFile.isMouseHere()) {
+          selectPlaybackFile.setIsActive(true);
+          selectPlaybackFilePressed = true;
+        }
 
-				if(chanButton8.isMouseHere()){
-					chanButton8.setIsActive(true);
-					chanButton8Pressed = true;
-					chanButton8.color_notPressed = color(184,220,105);
-					chanButton16.color_notPressed = color(255);
-				}
+        if (selectSDFile.isMouseHere()) {
+          selectSDFile.setIsActive(true);
+          selectSDFilePressed = true;
+        }
+      }
+    }
 
-				if(chanButton16.isMouseHere()){
-					chanButton16.setIsActive(true);
-					chanButton16Pressed = true;
-					chanButton8.color_notPressed = color(255);
-					chanButton16.color_notPressed = color(184,220,105);
-				}
-			}
+    // output("Text File Name: " + cp5.get(Textfield.class,"fileName").getText());
+  }
 
-			//active buttons during DATASOURCE_PLAYBACKFILE
-			if(eegDataSource == 1){
-				if(selectPlaybackFile.isMouseHere()){
-					selectPlaybackFile.setIsActive(true);
-					selectPlaybackFilePressed = true;
-				}
+  //mouse released in control panel
+  public void CPmouseReleased() {
+    verbosePrint("CPMouseReleased: CPmouseReleased start...");
+    if (initSystemButton.isMouseHere() && initButtonPressed) {
 
-				if(selectSDFile.isMouseHere()){
-					selectSDFile.setIsActive(true);
-					selectSDFilePressed = true;
-				}
-			}
-		}
+      //if system is not active ... initate system and flip button state
+      if (initSystemButton.but_txt == "START SYSTEM") {
 
-		// output("Text File Name: " + cp5.get(Textfield.class,"fileName").getText());
-	}
+        if ((eegDataSource == DATASOURCE_NORMAL || eegDataSource == DATASOURCE_NORMAL_W_AUX) && openBCI_portName == "N/A") { //if data source == normal && if no serial port selected OR no SD setting selected
+          output("No Serial/COM port selected. Please select your Serial/COM port and retry system initiation.");
+          initButtonPressed = false;
+          initSystemButton.setIsActive(false);
+          return;
+        } else if (eegDataSource == DATASOURCE_PLAYBACKFILE && playbackData_fname == "N/A") { //if data source == playback && playback file == 'N/A'
+          output("No playback file selected. Please select a playback file and retry system initiation.");				// tell user that they need to select a file before the system can be started
+          initButtonPressed = false;
+          initSystemButton.setIsActive(false);
+          return;
+        } else if (eegDataSource == -1) {//if no data source selected
+          output("No DATA SOURCE selected. Please select a DATA SOURCE and retry system initiation.");//tell user they must select a data source before initiating system
+          initButtonPressed = false;
+          initSystemButton.setIsActive(false);
+          return;
+        } else { //otherwise, initiate system!	
+          println("ControlPanel: CPmouseReleased: init");
+          initSystemButton.setString("STOP SYSTEM");
+          //global steps to START SYSTEM
+          // prepare the serial port
+          println("ControlPanel: CPmouseReleased: port is open? ... " + portIsOpen);
+          if (portIsOpen == true) {
+            openBCI.closeSerialPort();
+          }
+          fileName = cp5.get(Textfield.class, "fileName").getText(); // store the current text field value of "File Name" to be passed along to dataFiles 
+          initSystem();
+        }
+      }
 
-	//mouse released in control panel
-	public void CPmouseReleased(){
-		verbosePrint("CPMouseReleased: CPmouseReleased start...");
-		if(initSystemButton.isMouseHere() && initButtonPressed){
+      //if system is already active ... stop system and flip button state back
+      else {
+        output("SYSTEM STOPPED");
+        initSystemButton.setString("START SYSTEM");
+        haltSystem();
+      }
+    }
 
-			//if system is not active ... initate system and flip button state
-			if(initSystemButton.but_txt == "START SYSTEM"){
+    //open or close serial port if serial port button is pressed (left button in serial widget)
+    if (refreshPort.isMouseHere() && refreshButtonPressed) {
+      output("Serial/COM List Refreshed");
+      serialPorts = new String[Serial.list().length];
+      serialPorts = Serial.list();
+      serialList.items.clear();
+      for (int i = 0; i < serialPorts.length; i++) {
+        String tempPort = serialPorts[(serialPorts.length-1) - i]; //list backwards... because usually our port is at the bottom
+        serialList.addItem(makeItem(tempPort));
+      }
+      serialList.updateMenu();
+    }
 
-				if((eegDataSource == DATASOURCE_NORMAL || eegDataSource == DATASOURCE_NORMAL_W_AUX) && openBCI_portName == "N/A"){ //if data source == normal && if no serial port selected OR no SD setting selected
-					output("No Serial/COM port selected. Please select your Serial/COM port and retry system initiation.");
-					initButtonPressed = false;
-					initSystemButton.setIsActive(false);
-					return;
-				}
+    //open or close serial port if serial port button is pressed (left button in serial widget)
+    if (autoFileName.isMouseHere() && fileButtonPressed) {
+      output("Autogenerated \"File Name\" based on current date/time");
+      cp5.get(Textfield.class, "fileName").setText(getDateString());
+    }
 
-				else if(eegDataSource == DATASOURCE_PLAYBACKFILE && playbackData_fname == "N/A"){ //if data source == playback && playback file == 'N/A'
-					output("No playback file selected. Please select a playback file and retry system initiation.");				// tell user that they need to select a file before the system can be started
-					initButtonPressed = false;
-					initSystemButton.setIsActive(false);
-					return;
-				}
+    if (chanButton8.isMouseHere() && chanButton8Pressed) {
+      nchan = 8;
+      fftBuff = new FFT[nchan];   //from the minim library
+      yLittleBuff_uV = new float[nchan][nPointsPerUpdate];
+      output("channel count set to " + str(nchan));
+      updateChannelArrays(nchan); //make sure to reinitialize the channel arrays with the right number of channels
+    }
 
-				else if(eegDataSource == -1){//if no data source selected
-					output("No DATA SOURCE selected. Please select a DATA SOURCE and retry system initiation.");//tell user they must select a data source before initiating system
-					initButtonPressed = false;
-					initSystemButton.setIsActive(false);
-					return;
-				}
+    if (chanButton16.isMouseHere() && chanButton16Pressed) {
+      nchan = 16;
+      fftBuff = new FFT[nchan];  //reinitialize the FFT buffer
+      yLittleBuff_uV = new float[nchan][nPointsPerUpdate];
+      output("channel count set to " + str(nchan));
+      updateChannelArrays(nchan); //make sure to reinitialize the channel arrays with the right number of channels
+    }
 
-				else { //otherwise, initiate system!	
-					println("ControlPanel: CPmouseReleased: init");
-					initSystemButton.setString("STOP SYSTEM");
-					//global steps to START SYSTEM
-					// prepare the serial port
-				    println("ControlPanel: CPmouseReleased: port is open? ... " + portIsOpen);
-				    if(portIsOpen == true){
-				      openBCI.closeSerialPort();
-				    }
-				    fileName = cp5.get(Textfield.class,"fileName").getText(); // store the current text field value of "File Name" to be passed along to dataFiles 
-					initSystem();
-				}
-			}
+    if (selectPlaybackFile.isMouseHere() && selectPlaybackFilePressed) {
+      output("select a file for playback");
+      selectInput("Select a pre-recorded file for playback:", "playbackSelected");
+    }
 
-			//if system is already active ... stop system and flip button state back
-			else{
-				output("SYSTEM STOPPED");
-				initSystemButton.setString("START SYSTEM");
-				haltSystem();
-			}
-		}
+    if (selectSDFile.isMouseHere() && selectSDFilePressed) {
+      output("select an SD file to convert to a playback file");
+      createPlaybackFileFromSD();
+      selectInput("Select an SD file to convert for playback:", "sdFileSelected");
+    }
 
-		//open or close serial port if serial port button is pressed (left button in serial widget)
-		if(refreshPort.isMouseHere() && refreshButtonPressed){
-			output("Serial/COM List Refreshed");
-			serialPorts = new String[Serial.list().length];
-			serialPorts = Serial.list();
-			serialList.items.clear();
-			for(int i = 0; i < serialPorts.length; i++){
-				String tempPort = serialPorts[(serialPorts.length-1) - i]; //list backwards... because usually our port is at the bottom
-				serialList.addItem(makeItem(tempPort));
-			}
-			serialList.updateMenu();
-		}
-
-		//open or close serial port if serial port button is pressed (left button in serial widget)
-		if(autoFileName.isMouseHere() && fileButtonPressed){
-			output("Autogenerated \"File Name\" based on current date/time");
-			cp5.get(Textfield.class,"fileName").setText(getDateString());
-		}
-
-		if(chanButton8.isMouseHere() && chanButton8Pressed){
-			nchan = 8;
-			fftBuff = new FFT[nchan];   //from the minim library
-			yLittleBuff_uV = new float[nchan][nPointsPerUpdate];
-			output("channel count set to " + str(nchan));
-			updateChannelArrays(nchan); //make sure to reinitialize the channel arrays with the right number of channels
-		}
-
-		if(chanButton16.isMouseHere() && chanButton16Pressed){
-			nchan = 16;
-			fftBuff = new FFT[nchan];  //reinitialize the FFT buffer
-			yLittleBuff_uV = new float[nchan][nPointsPerUpdate];
-			output("channel count set to " + str(nchan));
-			updateChannelArrays(nchan); //make sure to reinitialize the channel arrays with the right number of channels
-		}
-
-		if(selectPlaybackFile.isMouseHere() && selectPlaybackFilePressed){
-			output("select a file for playback");
-			selectInput("Select a pre-recorded file for playback:", "playbackSelected");
-		}
-
-		if(selectSDFile.isMouseHere() && selectSDFilePressed){
-			output("select an SD file to convert to a playback file");
-			createPlaybackFileFromSD();
-			selectInput("Select an SD file to convert for playback:", "sdFileSelected");
-		}
-
-		//reset all buttons to false
-		refreshPort.setIsActive(false);
-		refreshButtonPressed = false;
-		initSystemButton.setIsActive(false);
-		initButtonPressed = false;
-		autoFileName.setIsActive(false);
-		fileButtonPressed = false;
-		chanButton8.setIsActive(false);
-		chanButton8Pressed = false;
-		chanButton16.setIsActive(false);
-		chanButton16Pressed = false;
-		selectPlaybackFile.setIsActive(false);
-		selectPlaybackFilePressed = false;
-		selectSDFile.setIsActive(false);
-		selectSDFilePressed = false;
-	}
+    //reset all buttons to false
+    refreshPort.setIsActive(false);
+    refreshButtonPressed = false;
+    initSystemButton.setIsActive(false);
+    initButtonPressed = false;
+    autoFileName.setIsActive(false);
+    fileButtonPressed = false;
+    chanButton8.setIsActive(false);
+    chanButton8Pressed = false;
+    chanButton16.setIsActive(false);
+    chanButton16Pressed = false;
+    selectPlaybackFile.setIsActive(false);
+    selectPlaybackFilePressed = false;
+    selectSDFile.setIsActive(false);
+    selectSDFilePressed = false;
+  }
 };
 
 public void controlEvent(ControlEvent theEvent) {
-	
-	if(theEvent.isFrom("sourceList")){
-		Map bob = ((MenuList)theEvent.getController()).getItem(int(theEvent.getValue()));
-		output("Data Source = " + (String)bob.get("headline"));
-		int newDataSource = int(theEvent.getValue());
-		eegDataSource = newDataSource; // reset global eegDataSource to the selected value from the list
-		output("The new data source is " + (String)bob.get("headline"));
-	}
 
-	if(theEvent.isFrom("serialList")){
-		Map bob = ((MenuList)theEvent.getController()).getItem(int(theEvent.getValue()));
-		openBCI_portName = (String)bob.get("headline");
-		output("OpenBCI Port Name = " + openBCI_portName);
-	}
+  if (theEvent.isFrom("sourceList")) {
+    Map bob = ((MenuList)theEvent.getController()).getItem(int(theEvent.getValue()));
+    output("Data Source = " + (String)bob.get("headline"));
+    int newDataSource = int(theEvent.getValue());
+    eegDataSource = newDataSource; // reset global eegDataSource to the selected value from the list
+    output("The new data source is " + (String)bob.get("headline"));
+  }
 
-	if(theEvent.isFrom("sdTimes")){
-		Map bob = ((MenuList)theEvent.getController()).getItem(int(theEvent.getValue()));
-		sdSettingString = (String)bob.get("headline");
-		sdSetting = int(theEvent.getValue());
-		if(sdSetting != 0){
-			output("OpenBCI microSD Setting = " + sdSettingString + " recording time");
-		} else{
-			output("OpenBCI microSD Setting = " + sdSettingString);
-		}
-		verbosePrint("SD setting = " + sdSetting);
-	}
+  if (theEvent.isFrom("serialList")) {
+    Map bob = ((MenuList)theEvent.getController()).getItem(int(theEvent.getValue()));
+    openBCI_portName = (String)bob.get("headline");
+    output("OpenBCI Port Name = " + openBCI_portName);
+  }
+
+  if (theEvent.isFrom("sdTimes")) {
+    Map bob = ((MenuList)theEvent.getController()).getItem(int(theEvent.getValue()));
+    sdSettingString = (String)bob.get("headline");
+    sdSetting = int(theEvent.getValue());
+    if (sdSetting != 0) {
+      output("OpenBCI microSD Setting = " + sdSettingString + " recording time");
+    } else {
+      output("OpenBCI microSD Setting = " + sdSettingString);
+    }
+    verbosePrint("SD setting = " + sdSetting);
+  }
 }
 
 //==============================================================================//
@@ -442,366 +432,351 @@ public void controlEvent(ControlEvent theEvent) {
 //==============================================================================//
 
 class DataSourceBox {
-	int x, y, w, h, padding; //size and position
+  int x, y, w, h, padding; //size and position
 
-	CheckBox sourceCheckBox;
+  CheckBox sourceCheckBox;
 
-	DataSourceBox(int _x, int _y, int _w, int _h, int _padding){
-		x = _x;
-		y = _y;
-		w = _w;
-		h = 115;
-		padding = _padding;
+  DataSourceBox(int _x, int _y, int _w, int _h, int _padding) {
+    x = _x;
+    y = _y;
+    w = _w;
+    h = 115;
+    padding = _padding;
 
-		sourceList = new MenuList(cp5, "sourceList", w - padding*2, 72, f2);
-		// sourceList.itemHeight = 28;
-		// sourceList.padding = 9;
-		sourceList.setPosition(x + padding, y + padding*2 + 13);
-		sourceList.addItem(makeItem("LIVE (from OpenBCI)                   >"));
-		sourceList.addItem(makeItem("PLAYBACK (from file)                  >"));
-		sourceList.addItem(makeItem("SYNTHETIC (algorithmic)           >"));
-		sourceList.scrollerLength = 10;
-	}
+    sourceList = new MenuList(cp5, "sourceList", w - padding*2, 72, f2);
+    // sourceList.itemHeight = 28;
+    // sourceList.padding = 9;
+    sourceList.setPosition(x + padding, y + padding*2 + 13);
+    sourceList.addItem(makeItem("LIVE (from OpenBCI)                   >"));
+    sourceList.addItem(makeItem("PLAYBACK (from file)                  >"));
+    sourceList.addItem(makeItem("SYNTHETIC (algorithmic)           >"));
+    sourceList.scrollerLength = 10;
+  }
 
-	public void update(){
+  public void update() {
+  }
 
-	}
-
-	public void draw(){
-		pushStyle();
-			fill(boxColor);
-			stroke(boxStrokeColor);
-			strokeWeight(1);
-			rect(x, y, w, h);
-			fill(bgColor);
-			textFont(f1);
-			textAlign(LEFT, TOP);
-			text("DATA SOURCE", x + padding, y + padding);
-		popStyle();
-			//draw contents of Data Source Box at top of control panel
-			//Title
-			//checkboxes of system states
-	}
+  public void draw() {
+    pushStyle();
+    fill(boxColor);
+    stroke(boxStrokeColor);
+    strokeWeight(1);
+    rect(x, y, w, h);
+    fill(bgColor);
+    textFont(f1);
+    textAlign(LEFT, TOP);
+    text("DATA SOURCE", x + padding, y + padding);
+    popStyle();
+    //draw contents of Data Source Box at top of control panel
+    //Title
+    //checkboxes of system states
+  }
 };
 
 class SerialBox {
-	int x, y, w, h, padding; //size and position
-	//connect/disconnect button
-	//Refresh list button
-	//String port status;
+  int x, y, w, h, padding; //size and position
+  //connect/disconnect button
+  //Refresh list button
+  //String port status;
 
-	SerialBox(int _x, int _y, int _w, int _h, int _padding){
-		x = _x;
-		y = _y;
-		w = _w;
-		h = 147;
-		padding = _padding;
+  SerialBox(int _x, int _y, int _w, int _h, int _padding) {
+    x = _x;
+    y = _y;
+    w = _w;
+    h = 147;
+    padding = _padding;
 
-		// openClosePort = new Button (padding + border, y + padding*3 + 13 + 150, (w-padding*3)/2, 24, "OPEN PORT", fontInfo.buttonLabel_size);
-		refreshPort = new Button (x + padding, y + padding*3 + 13 + 71, w - padding*2, 24, "REFRESH LIST", fontInfo.buttonLabel_size);
+    // openClosePort = new Button (padding + border, y + padding*3 + 13 + 150, (w-padding*3)/2, 24, "OPEN PORT", fontInfo.buttonLabel_size);
+    refreshPort = new Button (x + padding, y + padding*3 + 13 + 71, w - padding*2, 24, "REFRESH LIST", fontInfo.buttonLabel_size);
 
-		serialList = new MenuList(cp5, "serialList", w - padding*2, 72, f2);
-		serialList.setPosition(x + padding, y + padding*2 + 13);
-		serialPorts = Serial.list();
-		for(int i = 0; i < serialPorts.length; i++){
-			String tempPort = serialPorts[(serialPorts.length-1) - i]; //list backwards... because usually our port is at the bottom
-			serialList.addItem(makeItem(tempPort));
-		}
-	}
+    serialList = new MenuList(cp5, "serialList", w - padding*2, 72, f2);
+    serialList.setPosition(x + padding, y + padding*2 + 13);
+    serialPorts = Serial.list();
+    for (int i = 0; i < serialPorts.length; i++) {
+      String tempPort = serialPorts[(serialPorts.length-1) - i]; //list backwards... because usually our port is at the bottom
+      serialList.addItem(makeItem(tempPort));
+    }
+  }
 
-	public void update(){
-		// serialList.updateMenu();
-	}
+  public void update() {
+    // serialList.updateMenu();
+  }
 
-	public void draw(){
-		pushStyle();
-			fill(boxColor);
-			stroke(boxStrokeColor);
-			strokeWeight(1);
-			rect(x, y, w, h);
-			fill(bgColor);
-			textFont(f1);
-			textAlign(LEFT, TOP);
-			text("SERIAL/COM PORT", x + padding, y + padding);
-		popStyle();
+  public void draw() {
+    pushStyle();
+    fill(boxColor);
+    stroke(boxStrokeColor);
+    strokeWeight(1);
+    rect(x, y, w, h);
+    fill(bgColor);
+    textFont(f1);
+    textAlign(LEFT, TOP);
+    text("SERIAL/COM PORT", x + padding, y + padding);
+    popStyle();
 
-		// openClosePort.draw();
-		refreshPort.draw();
-	}
+    // openClosePort.draw();
+    refreshPort.draw();
+  }
 
-	public void refreshSerialList(){
-
-	}
+  public void refreshSerialList() {
+  }
 };
 
 class DataLogBox {
-	int x, y, w, h, padding; //size and position
-	String fileName;
-	//text field for inputing text
-	//create/open/closefile button
-	String fileStatus;
-	boolean isFileOpen; //true if file has been activated and is ready to write to
-	//String port status;
+  int x, y, w, h, padding; //size and position
+  String fileName;
+  //text field for inputing text
+  //create/open/closefile button
+  String fileStatus;
+  boolean isFileOpen; //true if file has been activated and is ready to write to
+  //String port status;
 
-	DataLogBox(int _x, int _y, int _w, int _h, int _padding){
-		x = _x;
-		y = _y;
-		w = _w;
-		h = 101;
-		padding = _padding;
-		//instantiate button
-		//figure out default file name (from Chip's code)
-		isFileOpen = false; //set to true on button push
-		fileStatus = "NO FILE CREATED";
+  DataLogBox(int _x, int _y, int _w, int _h, int _padding) {
+    x = _x;
+    y = _y;
+    w = _w;
+    h = 101;
+    padding = _padding;
+    //instantiate button
+    //figure out default file name (from Chip's code)
+    isFileOpen = false; //set to true on button push
+    fileStatus = "NO FILE CREATED";
 
-		//button to autogenerate file name based on time/date
-		autoFileName = new Button (x + padding, y + 66, w-(padding*2), 24, "AUTOGENERATE FILE NAME", fontInfo.buttonLabel_size);
+    //button to autogenerate file name based on time/date
+    autoFileName = new Button (x + padding, y + 66, w-(padding*2), 24, "AUTOGENERATE FILE NAME", fontInfo.buttonLabel_size);
 
-		cp5.addTextfield("fileName")
-			.setPosition(x + 90,y + 32)
-			.setCaptionLabel("")
-			.setSize(157,26)
-			.setFont(f2)
-			.setFocus(false)
-			.setColor(color(26,26,26))
-			.setColorBackground(color(255,255,255)) // text field bg color
-			.setColorValueLabel(color(0,0,0))  // text color
-			.setColorForeground(greenColor)  // border color when not selected
-			.setColorActive(greenColor)  // border color when selected
-			.setColorCursor(color(26,26,26)) 
-			.setText(getDateString())
-			.align(5, 10, 20, 40) 
-			.onDoublePress(cb) 
-			.setAutoClear(true)
-			;
+    cp5.addTextfield("fileName")
+      .setPosition(x + 90, y + 32)
+      .setCaptionLabel("")
+      .setSize(157, 26)
+      .setFont(f2)
+      .setFocus(false)
+      .setColor(color(26, 26, 26))
+      .setColorBackground(color(255, 255, 255)) // text field bg color
+      .setColorValueLabel(color(0, 0, 0))  // text color
+      .setColorForeground(greenColor)  // border color when not selected
+      .setColorActive(greenColor)  // border color when selected
+      .setColorCursor(color(26, 26, 26)) 
+      .setText(getDateString())
+      .align(5, 10, 20, 40) 
+      .onDoublePress(cb) 
+      .setAutoClear(true);
 
-			//clear text field on double click
+    //clear text field on double click
+  }
 
-	}
+  public void update() {
+  }
 
-	public void update(){
-
-	}
-
-	public void draw(){
-		pushStyle();
-			fill(boxColor);
-			stroke(boxStrokeColor);
-			strokeWeight(1);
-			rect(x, y, w, h);
-			fill(bgColor);
-			textFont(f1);
-			textAlign(LEFT, TOP);
-			text("DATA LOG FILE", x + padding, y + padding);
-			textFont(f3);
-			text("File Name", x + padding, y + padding*2 + 18);
-		popStyle();
-		autoFileName.draw();
-	}
+  public void draw() {
+    pushStyle();
+    fill(boxColor);
+    stroke(boxStrokeColor);
+    strokeWeight(1);
+    rect(x, y, w, h);
+    fill(bgColor);
+    textFont(f1);
+    textAlign(LEFT, TOP);
+    text("DATA LOG FILE", x + padding, y + padding);
+    textFont(f3);
+    text("File Name", x + padding, y + padding*2 + 18);
+    popStyle();
+    autoFileName.draw();
+  }
 };
 
 class ChannelCountBox {
-	int x, y, w, h, padding; //size and position
+  int x, y, w, h, padding; //size and position
 
-	boolean isSystemInitialized;
-	// button for init/halt system
+  boolean isSystemInitialized;
+  // button for init/halt system
 
-	ChannelCountBox(int _x, int _y, int _w, int _h, int _padding){
-		x = _x;
-		y = _y;
-		w = _w;
-		h = 73;
-		padding = _padding;
+  ChannelCountBox(int _x, int _y, int _w, int _h, int _padding) {
+    x = _x;
+    y = _y;
+    w = _w;
+    h = 73;
+    padding = _padding;
 
-		chanButton8 = new Button (x + padding, y + padding*2 + 18, (w-padding*3)/2, 24, "8 CHANNELS", fontInfo.buttonLabel_size);
-		chanButton8.color_notPressed = color(184,220,105);
-		chanButton16 = new Button (x + padding*2 + (w-padding*3)/2, y + padding*2 + 18, (w-padding*3)/2, 24, "16 CHANNELS", fontInfo.buttonLabel_size);
+    chanButton8 = new Button (x + padding, y + padding*2 + 18, (w-padding*3)/2, 24, "8 CHANNELS", fontInfo.buttonLabel_size);
+    chanButton8.color_notPressed = color(184, 220, 105);
+    chanButton16 = new Button (x + padding*2 + (w-padding*3)/2, y + padding*2 + 18, (w-padding*3)/2, 24, "16 CHANNELS", fontInfo.buttonLabel_size);
+  }
 
-	}
+  public void update() {
+  }
 
-	public void update(){
+  public void draw() {
+    pushStyle();
+    fill(boxColor);
+    stroke(boxStrokeColor);
+    strokeWeight(1);
+    rect(x, y, w, h);
+    fill(bgColor);
+    textFont(f1);
+    textAlign(LEFT, TOP);
+    text("CHANNEL COUNT", x + padding, y + padding);
+    fill(bgColor); //set color to green
+    textFont(f1);
+    textAlign(LEFT, TOP);
+    text("(" + str(nchan) + ")", x + padding + 142, y + padding); // print the channel count in green next to the box title
+    popStyle();
 
-	}
-	
-	public void draw(){
-		pushStyle();
-			fill(boxColor);
-			stroke(boxStrokeColor);
-			strokeWeight(1);
-			rect(x, y, w, h);
-			fill(bgColor);
-			textFont(f1);
-			textAlign(LEFT, TOP);
-			text("CHANNEL COUNT", x + padding, y + padding);
-			fill(bgColor); //set color to green
-			textFont(f1);
-			textAlign(LEFT, TOP);
-			text("(" + str(nchan) + ")", x + padding + 142, y + padding); // print the channel count in green next to the box title
-		popStyle();
-
-		chanButton8.draw();
-		chanButton16.draw();
-	}
+    chanButton8.draw();
+    chanButton16.draw();
+  }
 };
 
 class PlaybackFileBox {
-	int x, y, w, h, padding; //size and position
+  int x, y, w, h, padding; //size and position
 
-	PlaybackFileBox(int _x, int _y, int _w, int _h, int _padding){
-		x = _x;
-		y = _y;
-		w = _w;
-		h = 67;
-		padding = _padding;
+  PlaybackFileBox(int _x, int _y, int _w, int _h, int _padding) {
+    x = _x;
+    y = _y;
+    w = _w;
+    h = 67;
+    padding = _padding;
 
-		selectPlaybackFile = new Button (x + padding, y + padding*2 + 13, w - padding*2, 24, "SELECT PLAYBACK FILE", fontInfo.buttonLabel_size);
+    selectPlaybackFile = new Button (x + padding, y + padding*2 + 13, w - padding*2, 24, "SELECT PLAYBACK FILE", fontInfo.buttonLabel_size);
+  }
 
-	}
+  public void update() {
+  }
 
-	public void update(){
+  public void draw() {
+    pushStyle();
+    fill(boxColor);
+    stroke(boxStrokeColor);
+    strokeWeight(1);
+    rect(x, y, w, h);
+    fill(bgColor);
+    textFont(f1);
+    textAlign(LEFT, TOP);
+    text("PLAYBACK FILE", x + padding, y + padding);
+    popStyle();
 
-	}
-	
-	public void draw(){
-		pushStyle();
-			fill(boxColor);
-			stroke(boxStrokeColor);
-			strokeWeight(1);
-			rect(x, y, w, h);
-			fill(bgColor);
-			textFont(f1);
-			textAlign(LEFT, TOP);
-			text("PLAYBACK FILE", x + padding, y + padding);
-		popStyle();
-
-		selectPlaybackFile.draw();
-		// chanButton16.draw();
-	}
+    selectPlaybackFile.draw();
+    // chanButton16.draw();
+  }
 };
 
 class SDBox {
-	int x, y, w, h, padding; //size and position
+  int x, y, w, h, padding; //size and position
 
-	SDBox(int _x, int _y, int _w, int _h, int _padding){
-		x = _x;
-		y = _y;
-		w = _w;
-		h = 150;
-		padding = _padding;
+  SDBox(int _x, int _y, int _w, int _h, int _padding) {
+    x = _x;
+    y = _y;
+    w = _w;
+    h = 150;
+    padding = _padding;
 
-		sdTimes = new MenuList(cp5, "sdTimes", w - padding*2, 108, f2);
-		sdTimes.setPosition(x + padding, y + padding*2 + 13);
-		serialPorts = Serial.list();
+    sdTimes = new MenuList(cp5, "sdTimes", w - padding*2, 108, f2);
+    sdTimes.setPosition(x + padding, y + padding*2 + 13);
+    serialPorts = Serial.list();
 
-		//add items for the various SD times
-		sdTimes.addItem(makeItem("Do not write to SD..."));
-		sdTimes.addItem(makeItem("5 minute maximum"));
-		sdTimes.addItem(makeItem("15 minute maximum"));
-		sdTimes.addItem(makeItem("30 minute maximum"));
-		sdTimes.addItem(makeItem("1 hour maximum"));
-		sdTimes.addItem(makeItem("2 hours maximum"));
-		sdTimes.addItem(makeItem("4 hour maximum"));
-		sdTimes.addItem(makeItem("12 hour maximum"));
-		sdTimes.addItem(makeItem("24 hour maximum"));
-	}
+    //add items for the various SD times
+    sdTimes.addItem(makeItem("Do not write to SD..."));
+    sdTimes.addItem(makeItem("5 minute maximum"));
+    sdTimes.addItem(makeItem("15 minute maximum"));
+    sdTimes.addItem(makeItem("30 minute maximum"));
+    sdTimes.addItem(makeItem("1 hour maximum"));
+    sdTimes.addItem(makeItem("2 hours maximum"));
+    sdTimes.addItem(makeItem("4 hour maximum"));
+    sdTimes.addItem(makeItem("12 hour maximum"));
+    sdTimes.addItem(makeItem("24 hour maximum"));
+  }
 
-	public void update(){
+  public void update() {
+  }
 
-	}
-	
-	public void draw(){
-		pushStyle();
-			fill(boxColor);
-			stroke(boxStrokeColor);
-			strokeWeight(1);
-			rect(x, y, w, h);
-			fill(bgColor);
-			textFont(f1);
-			textAlign(LEFT, TOP);
-			text("WRITE TO SD (Y/N)?", x + padding, y + padding);
-		popStyle();
+  public void draw() {
+    pushStyle();
+    fill(boxColor);
+    stroke(boxStrokeColor);
+    strokeWeight(1);
+    rect(x, y, w, h);
+    fill(bgColor);
+    textFont(f1);
+    textAlign(LEFT, TOP);
+    text("WRITE TO SD (Y/N)?", x + padding, y + padding);
+    popStyle();
 
-		// chanButton8.draw();
-		// chanButton16.draw();
-	}
+    // chanButton8.draw();
+    // chanButton16.draw();
+  }
 };
 
 class SDConverterBox {
-	int x, y, w, h, padding; //size and position
+  int x, y, w, h, padding; //size and position
 
-	SDConverterBox(int _x, int _y, int _w, int _h, int _padding){
-		x = _x;
-		y = _y;
-		w = _w;
-		h = 67;
-		padding = _padding;
+  SDConverterBox(int _x, int _y, int _w, int _h, int _padding) {
+    x = _x;
+    y = _y;
+    w = _w;
+    h = 67;
+    padding = _padding;
 
-		selectSDFile = new Button (x + padding, y + padding*2 + 13, w - padding*2, 24, "SELECT SD FILE", fontInfo.buttonLabel_size);
+    selectSDFile = new Button (x + padding, y + padding*2 + 13, w - padding*2, 24, "SELECT SD FILE", fontInfo.buttonLabel_size);
+  }
 
-	}
+  public void update() {
+  }
 
-	public void update(){
+  public void draw() {
+    pushStyle();
+    fill(boxColor);
+    stroke(boxStrokeColor);
+    strokeWeight(1);
+    rect(x, y, w, h);
+    fill(bgColor);
+    textFont(f1);
+    textAlign(LEFT, TOP);
+    text("CONVERT SD FOR PLAYBACK", x + padding, y + padding);
+    popStyle();
 
-	}
-	
-	public void draw(){
-		pushStyle();
-			fill(boxColor);
-			stroke(boxStrokeColor);
-			strokeWeight(1);
-			rect(x, y, w, h);
-			fill(bgColor);
-			textFont(f1);
-			textAlign(LEFT, TOP);
-			text("CONVERT SD FOR PLAYBACK", x + padding, y + padding);
-		popStyle();
-
-		selectSDFile.draw();
-		// chanButton16.draw();
-	}
+    selectSDFile.draw();
+    // chanButton16.draw();
+  }
 };
 
 class InitBox {
-	int x, y, w, h, padding; //size and position
+  int x, y, w, h, padding; //size and position
 
-	boolean initButtonPressed; //default false
+  boolean initButtonPressed; //default false
 
-	boolean isSystemInitialized;
-	// button for init/halt system
+  boolean isSystemInitialized;
+  // button for init/halt system
 
-	InitBox(int _x, int _y, int _w, int _h, int _padding){
-		x = _x;
-		y = _y;
-		w = _w;
-		h = 50;
-		padding = _padding;
+  InitBox(int _x, int _y, int _w, int _h, int _padding) {
+    x = _x;
+    y = _y;
+    w = _w;
+    h = 50;
+    padding = _padding;
 
-		//init button
-		initSystemButton = new Button (padding, y + padding, w-padding*2, h - padding*2, "START SYSTEM", fontInfo.buttonLabel_size);
-		initSystemButton.color_notPressed = color(boxColor);
-		initSystemButton.buttonStrokeColor = color(boxColor);
-		initButtonPressed = false;
-	}
+    //init button
+    initSystemButton = new Button (padding, y + padding, w-padding*2, h - padding*2, "START SYSTEM", fontInfo.buttonLabel_size);
+    initSystemButton.color_notPressed = color(boxColor);
+    initSystemButton.buttonStrokeColor = color(boxColor);
+    initButtonPressed = false;
+  }
 
-	public void update(){
+  public void update() {
+  }
 
-	}
+  public void draw() {
 
-	public void draw(){
-
-		pushStyle();
-			fill(255);
-			stroke(boxStrokeColor);
-			strokeWeight(1);
-			rect(x, y, w, h);
-		popStyle();
-		initSystemButton.draw();
-
-	}
-
+    pushStyle();
+    fill(255);
+    stroke(boxStrokeColor);
+    strokeWeight(1);
+    rect(x, y, w, h);
+    popStyle();
+    initSystemButton.draw();
+  }
 };
 
-void playbackSelected(File selection){
+void playbackSelected(File selection) {
   if (selection == null) {
     println("ControlPanel: playbackSelected: Window was closed or the user hit cancel.");
   } else {
@@ -810,7 +785,6 @@ void playbackSelected(File selection){
     playbackData_fname = selection.getAbsolutePath();
   }
 }
-
 
 
 

--- a/OpenBCI_GUI/ControlPanel.pde
+++ b/OpenBCI_GUI/ControlPanel.pde
@@ -685,6 +685,8 @@ class SDBox {
     sdTimes.addItem(makeItem("4 hour maximum"));
     sdTimes.addItem(makeItem("12 hour maximum"));
     sdTimes.addItem(makeItem("24 hour maximum"));
+    
+    sdTimes.activeItem = sdSetting; //added to indicate default choice (sdSetting is in OpenBCI_GUI)
   }
 
   public void update() {

--- a/OpenBCI_GUI/ControlPanel.pde
+++ b/OpenBCI_GUI/ControlPanel.pde
@@ -37,7 +37,7 @@ MenuList sdTimes;
 color boxColor = color(200);
 // color boxStrokeColor = color(173,183,192);
 color boxStrokeColor = color(138, 146, 153);
-color greenColor = color(184, 220, 105);
+color isSelected_color = color(184, 220, 105);
 
 // Button openClosePort;
 // boolean portButtonPressed;
@@ -259,7 +259,7 @@ class ControlPanel {
         if (chanButton8.isMouseHere()) {
           chanButton8.setIsActive(true);
           chanButton8Pressed = true;
-          chanButton8.color_notPressed = color(184, 220, 105);
+          chanButton8.color_notPressed = isSelected_color;
           chanButton16.color_notPressed = color(255);
         }
 
@@ -267,7 +267,7 @@ class ControlPanel {
           chanButton16.setIsActive(true);
           chanButton16Pressed = true;
           chanButton8.color_notPressed = color(255);
-          chanButton16.color_notPressed = color(184, 220, 105);
+          chanButton16.color_notPressed = isSelected_color;
         }
       }
 
@@ -554,8 +554,8 @@ class DataLogBox {
       .setColor(color(26, 26, 26))
       .setColorBackground(color(255, 255, 255)) // text field bg color
       .setColorValueLabel(color(0, 0, 0))  // text color
-      .setColorForeground(greenColor)  // border color when not selected
-      .setColorActive(greenColor)  // border color when selected
+      .setColorForeground(isSelected_color)  // border color when not selected
+      .setColorActive(isSelected_color)  // border color when selected
       .setColorCursor(color(26, 26, 26)) 
       .setText(getDateString())
       .align(5, 10, 20, 40) 
@@ -599,8 +599,9 @@ class ChannelCountBox {
     padding = _padding;
 
     chanButton8 = new Button (x + padding, y + padding*2 + 18, (w-padding*3)/2, 24, "8 CHANNELS", fontInfo.buttonLabel_size);
-    chanButton8.color_notPressed = color(184, 220, 105);
+    if (nchan == 8) chanButton8.color_notPressed = isSelected_color; //make it appear like this one is already selected
     chanButton16 = new Button (x + padding*2 + (w-padding*3)/2, y + padding*2 + 18, (w-padding*3)/2, 24, "16 CHANNELS", fontInfo.buttonLabel_size);
+    if (nchan == 16) chanButton16.color_notPressed = isSelected_color; //make it appear like this one is already selected
   }
 
   public void update() {
@@ -700,9 +701,9 @@ class SDBox {
     textAlign(LEFT, TOP);
     text("WRITE TO SD (Y/N)?", x + padding, y + padding);
     popStyle();
+  
+    //the drawing of the sdTimes is handled earlier in ControlPanel.draw()
 
-    // chanButton8.draw();
-    // chanButton16.draw();
   }
 };
 
@@ -735,7 +736,6 @@ class SDConverterBox {
     popStyle();
 
     selectSDFile.draw();
-    // chanButton16.draw();
   }
 };
 

--- a/OpenBCI_GUI/ControlPanel.pde
+++ b/OpenBCI_GUI/ControlPanel.pde
@@ -21,7 +21,7 @@ import controlP5.*;
 ControlP5 cp5; //program-wide instance of ControlP5
 CallbackListener cb = new CallbackListener() { //used by ControlP5 to clear text field on double-click
     public void controlEvent(CallbackEvent theEvent) {
-    	println("clearing");
+    	println("CallbackListener: controlEvent: clearing");
     	cp5.get(Textfield.class,"fileName").clear();
     }
 };
@@ -294,7 +294,7 @@ class ControlPanel {
 
 	//mouse released in control panel
 	public void CPmouseReleased(){
-		verbosePrint("CPMouseReleased");
+		verbosePrint("CPMouseReleased: CPmouseReleased start...");
 		if(initSystemButton.isMouseHere() && initButtonPressed){
 
 			//if system is not active ... initate system and flip button state
@@ -322,11 +322,11 @@ class ControlPanel {
 				}
 
 				else { //otherwise, initiate system!	
-					println("init");
+					println("ControlPanel: CPmouseReleased: init");
 					initSystemButton.setString("STOP SYSTEM");
 					//global steps to START SYSTEM
 					// prepare the serial port
-				    println("port is open? ... " + portIsOpen);
+				    println("ControlPanel: CPmouseReleased: port is open? ... " + portIsOpen);
 				    if(portIsOpen == true){
 				      openBCI.closeSerialPort();
 				    }
@@ -803,9 +803,9 @@ class InitBox {
 
 void playbackSelected(File selection){
   if (selection == null) {
-    println("Window was closed or the user hit cancel.");
+    println("ControlPanel: playbackSelected: Window was closed or the user hit cancel.");
   } else {
-    println("User selected " + selection.getAbsolutePath());
+    println("ControlPanel: playbackSelected: User selected " + selection.getAbsolutePath());
     output("You have selected \"" + selection.getAbsolutePath() + "\" for playback.");
     playbackData_fname = selection.getAbsolutePath();
   }

--- a/OpenBCI_GUI/ControlPanel.pde
+++ b/OpenBCI_GUI/ControlPanel.pde
@@ -316,8 +316,8 @@ class ControlPanel {
           initSystemButton.setString("STOP SYSTEM");
           //global steps to START SYSTEM
           // prepare the serial port
-          println("ControlPanel: CPmouseReleased: port is open? ... " + portIsOpen);
-          if (portIsOpen == true) {
+          println("ControlPanel: CPmouseReleased: port is open? ... " + openBCI.isSerialPortOpen());
+          if (openBCI.isSerialPortOpen() == true) {
             openBCI.closeSerialPort();
           }
           fileName = cp5.get(Textfield.class, "fileName").getText(); // store the current text field value of "File Name" to be passed along to dataFiles 

--- a/OpenBCI_GUI/Gui_Manager.pde
+++ b/OpenBCI_GUI/Gui_Manager.pde
@@ -140,7 +140,7 @@ class Gui_Manager {
     gMontage = new Graph2D(parent, int(axes_x), int(axes_y), false);  //last argument is whether the axes cross at zero
     setupMontagePlot(gMontage, win_x, win_y, axisMontage_relPos,displayTime_sec,fontInfo,filterDescription);
 
-    println("Buttons: " + int(float(win_x)*axisMontage_relPos[0]) + ", " + (int(float(win_y)*axisMontage_relPos[1])-40));
+    println("Gui_Manager: Buttons: " + int(float(win_x)*axisMontage_relPos[0]) + ", " + (int(float(win_y)*axisMontage_relPos[1])-40));
 
     showMontageButton = new Button (int(float(win_x)*axisMontage_relPos[0]) - 1, int(float(win_y)*axisMontage_relPos[1])-45, 125, 21, "EEG DATA", 14); 
     showMontageButton.makeDropdownButton(true);
@@ -870,7 +870,7 @@ class Gui_Manager {
   }
 
   public void mousePressed(){
-    verbosePrint("gui.mousePressed();");
+    verbosePrint("Gui_Manager: mousePressed: mouse pressed.");
     //if showMontage button pressed
     if(showMontageButton.isMouseHere()){
       //turn off visibility of channel full controller
@@ -891,7 +891,7 @@ class Gui_Manager {
 
     //if cursor inside channel controller
     // if(mouseX >= cc.x1 && mouseX <= (cc.x2 - cc.w2) && mouseY >= cc.y1 && mouseY <= (cc.y1 + cc.h1) ){ 
-      verbosePrint("Channel Controller mouse pressed...");
+      verbosePrint("Gui_Manager: mousePressed: Channel Controller mouse pressed...");
       cc.mousePressed();
     // }
     
@@ -904,10 +904,10 @@ class Gui_Manager {
   }
 
   public void mouseReleased(){
-    verbosePrint("gui.mouseReleased();");
+    //verbosePrint("Gui_Manager: mouseReleased()");
 
     // if(mouseX >= cc.x1 && mouseX <= (cc.x2 - cc.w2) && mouseY >= cc.y1 && mouseY <= (cc.y1 + cc.h1) ){ 
-    verbosePrint("Channel Controller mouse released...");
+    verbosePrint("Gui_Manager: mouseReleased(): Channel Controller mouse released...");
     cc.mouseReleased();
 
 

--- a/OpenBCI_GUI/HelpWidget.pde
+++ b/OpenBCI_GUI/HelpWidget.pde
@@ -3,58 +3,56 @@
 
 class HelpWidget {
 
-	public float x, y, w, h;
-	// ArrayList<String> prevOutputs; //growing list of all previous system interactivity
+  public float x, y, w, h;
+  // ArrayList<String> prevOutputs; //growing list of all previous system interactivity
 
-	String currentOutput = "..."; //current text shown in help widget, based on most recent command
+  String currentOutput = "..."; //current text shown in help widget, based on most recent command
 
-	int padding = 5;
+  int padding = 5;
 
-	HelpWidget(float _xPos, float _yPos, float _width, float _height){
-		x = _xPos;
-		y = _yPos;
-		w = _width;
-		h = _height;
-	}
+  HelpWidget(float _xPos, float _yPos, float _width, float _height) {
+    x = _xPos;
+    y = _yPos;
+    w = _width;
+    h = _height;
+  }
 
-	public void update(){
+  public void update() {
+  }
 
-	}
+  public void draw() {
 
-	public void draw(){
+    pushStyle();
+    noStroke();
 
-		pushStyle();
-		noStroke();
+    // draw background of widget
+    fill(255);
+    rect(x, height-h, width, h);
 
-		// draw background of widget
-		fill(255);
-		rect(x,height-h,width,h);
+    //draw bg of text field of widget
+    strokeWeight(1);
+    stroke(color(0, 5, 11));
+    fill(color(0, 5, 11));
+    rect(x + padding, height-h + padding, width - padding*5 - 128, h - padding *2);
 
-		//draw bg of text field of widget
-		strokeWeight(1);
-		stroke(color(0,5,11));
-		fill(color(0,5,11));
-		rect(x + padding, height-h + padding, width - padding*5 - 128, h - padding *2);
+    textSize(14);
+    fill(255);
+    textAlign(LEFT, TOP);
+    text(currentOutput, padding*2, height - h + padding + 4);
 
-		textSize(14);
-		fill(255);
-		textAlign(LEFT, TOP);
-		text(currentOutput, padding*2, height - h + padding + 4);
+    //draw OpenBCI LOGO
+    image(logo, width - (128+padding*2), height - 26, 128, 22);
 
-		//draw OpenBCI LOGO
-		image(logo, width - (128+padding*2), height - 26, 128, 22);
+    popStyle();
+  }
 
-		popStyle();
-
-	}
-
-	public void output(String _output){	
-		currentOutput = _output;
-		// prevOutputs.add(_output);
-	}
+  public void output(String _output) {	
+    currentOutput = _output;
+    // prevOutputs.add(_output);
+  }
 };
 
-public void output(String _output){
-	helpWidget.output(_output);
+public void output(String _output) {
+  helpWidget.output(_output);
 }
 

--- a/OpenBCI_GUI/MenuList.pde
+++ b/OpenBCI_GUI/MenuList.pde
@@ -28,23 +28,23 @@ public class MenuList extends Controller {
   int activeItem = -1;
   PFont menuFont = f2; 
   int padding = 7;
-  
+
 
   MenuList(ControlP5 c, String theName, int theWidth, int theHeight, PFont theFont) {
-    
+
     super( c, theName, 0, 0, theWidth, theHeight );
     c.register( this );
-    menu = createGraphics(getWidth(), getHeight() );
+    menu = createGraphics(getWidth(),getHeight());
 
     menuFont = theFont;
 
     setView(new ControllerView<MenuList>() {
 
-      public void display(PGraphics pg, MenuList t ) {
+      public void display(PGraphics pg, MenuList t) {
         if (updateMenu) {
           updateMenu();
         }
-        if (inside() ) {
+        if (inside()) {
           menu.beginDraw();
           int len = -(itemHeight * items.size()) + getHeight();
           int ty = int(map(pos, len, 0, getHeight() - scrollerLength - 2, 2 ) );
@@ -64,7 +64,7 @@ public class MenuList extends Controller {
     int len = -(itemHeight * items.size()) + getHeight();
     npos = constrain(npos, len, 0);
     pos += (npos - pos) * 0.1;
-//    pos += (npos - pos) * 0.1;
+    //    pos += (npos - pos) * 0.1;
     menu.beginDraw();
     menu.noStroke();
     menu.background(255, 64);
@@ -79,32 +79,32 @@ public class MenuList extends Controller {
 
     menu.translate(0, i0*itemHeight);
 
-    for (int i=i0;i<i1;i++) {
-		Map m = items.get(i);
-		menu.fill(255, 100);
-		if(i == hoverItem){
-			menu.fill(127,134,143);
-		}
-		if(i == activeItem){
-			menu.stroke(184,220,105,255);
-			menu.strokeWeight(1);
-			menu.fill(184,220,105,255);
-			menu.rect(0, 0, getWidth()-1, itemHeight-1 );
-			menu.noStroke();
-		} else{
-			menu.rect(0, 0, getWidth(), itemHeight-1 );
-		}
-			menu.fill(bgColor);
-			menu.textFont(menuFont);
-			menu.text(m.get("headline").toString(), 8, itemHeight - padding); // 5/17
-			menu.translate( 0, itemHeight );
+    for (int i=i0; i<i1; i++) {
+      Map m = items.get(i);
+      menu.fill(255, 100);
+      if (i == hoverItem) {
+        menu.fill(127, 134, 143);
+      }
+      if (i == activeItem) {
+        menu.stroke(184, 220, 105, 255);
+        menu.strokeWeight(1);
+        menu.fill(184, 220, 105, 255);
+        menu.rect(0, 0, getWidth()-1, itemHeight-1 );
+        menu.noStroke();
+      } else {
+        menu.rect(0, 0, getWidth(), itemHeight-1 );
+      }
+      menu.fill(bgColor);
+      menu.textFont(menuFont);
+      menu.text(m.get("headline").toString(), 8, itemHeight - padding); // 5/17
+      menu.translate( 0, itemHeight );
     }
     menu.popMatrix();
     menu.popMatrix();
     menu.endDraw();
     updateMenu = abs(npos-pos)>0.01 ? true:false;
   }
-  
+
   /* when detecting a click, check if the click happend to the far right, if yes, scroll to that position, 
    * otherwise do whatever this item of the list is supposed to do.
    */
@@ -112,8 +112,7 @@ public class MenuList extends Controller {
     if (getPointer().x()>getWidth()-scrollerWidth) {
       npos= -map(getPointer().y(), 0, getHeight(), 0, items.size()*itemHeight);
       updateMenu = true;
-    } 
-    else {
+    } else {
       int len = itemHeight * items.size();
       int index = int( map( getPointer().y() - pos, 0, len, 0, items.size() ) ) ;
       setValue(index);
@@ -121,12 +120,11 @@ public class MenuList extends Controller {
     }
     updateMenu = true;
   }
-  
+
   public void onMove() {
     if (getPointer().x()>getWidth() || getPointer().x()<0 || getPointer().y()<0  || getPointer().y()>getHeight() ) {
       hoverItem = -1;
-    } 
-    else {
+    } else {
       int len = itemHeight * items.size();
       int index = int( map( getPointer().y() - pos, 0, len, 0, items.size() ) ) ;
       hoverItem = index;
@@ -138,8 +136,7 @@ public class MenuList extends Controller {
     if (getPointer().x()>getWidth()-scrollerWidth) {
       npos= -map(getPointer().y(), 0, getHeight(), 0, items.size()*itemHeight);
       updateMenu = true;
-    } 
-    else{
+    } else {
       npos += getPointer().dy() * 2;
       updateMenu = true;
     }
@@ -159,10 +156,9 @@ public class MenuList extends Controller {
     items.remove(m);
     updateMenu = true;
   }
-  
-  Map<String,Object> getItem(int theIndex) {
+
+  Map<String, Object> getItem(int theIndex) {
     return items.get(theIndex);
   }
 };
-
 

--- a/OpenBCI_GUI/MenuList.pde
+++ b/OpenBCI_GUI/MenuList.pde
@@ -133,7 +133,7 @@ public class MenuList extends Controller {
   }
 
   public void onDrag() {
-    if (getPointer().x()>getWidth()-scrollerWidth) {
+    if (getPointer().x() > (getWidth()-scrollerWidth)) {
       npos= -map(getPointer().y(), 0, getHeight(), 0, items.size()*itemHeight);
       updateMenu = true;
     } else {

--- a/OpenBCI_GUI/OpenBCI_ADS1299.pde
+++ b/OpenBCI_GUI/OpenBCI_ADS1299.pde
@@ -687,6 +687,7 @@ class OpenBCI_ADS1299 {
   }
   
   public int copyDataPacketTo(DataPacket_ADS1299 target) {
+    isNewDataPacketAvailable = false;
     return dataPacket.copyTo(target);
   }
  

--- a/OpenBCI_GUI/OpenBCI_ADS1299.pde
+++ b/OpenBCI_GUI/OpenBCI_ADS1299.pde
@@ -690,5 +690,107 @@ class OpenBCI_ADS1299 {
     return dataPacket.copyTo(target);
   }
  
+ 
+  public long timeOfLastChannelWrite = 0;
+  public int channelWriteCounter = 0;
+  public boolean isWritingChannel = false;
+  public void initChannelWrite(int _numChannel) {  //numChannel counts from zero
+      timeOfLastChannelWrite = millis();
+      isWritingChannel = true;
+  }
+  public void writeChannelSettings(int _numChannel,char[][] channelSettingValues) {   //numChannel counts from zero
+    if (millis() - timeOfLastChannelWrite >= 50) { //wait 50 milliseconds before sending next character
+      verbosePrint("---");
+      switch (channelWriteCounter) {
+        case 0: //start sequence by send 'x'
+          verbosePrint("x" + " :: " + millis());
+          serial_openBCI.write('x');
+          break;
+        case 1: //send channel number
+          verbosePrint(str(_numChannel+1) + " :: " + millis());
+          if (_numChannel < 8) {
+            serial_openBCI.write((char)('0'+(_numChannel+1)));
+          }
+          if (_numChannel >= 8) {
+            //openBCI.serial_openBCI.write((command_activate_channel_daisy[_numChannel-8]));
+            serial_openBCI.write((command_activate_channel[_numChannel])); //command_activate_channel holds non-daisy and daisy
+          }
+          break;
+        case 2: 
+        case 3: 
+        case 4: 
+        case 5: 
+        case 6: 
+        case 7:
+          verbosePrint(channelSettingValues[_numChannel][channelWriteCounter-2] + " :: " + millis());
+          serial_openBCI.write(channelSettingValues[_numChannel][channelWriteCounter-2]);
+          //value for ON/OF
+          break;
+        case 8:
+          verbosePrint("X" + " :: " + millis());
+          serial_openBCI.write('X'); // send 'X' to end message sequence
+          break;
+        case 9:
+          verbosePrint("done writing channel.");
+          isWritingChannel = false;
+          channelWriteCounter = -1;
+          break;
+      }
+      timeOfLastChannelWrite = millis();
+      channelWriteCounter++;
+    }
+  }
+  
+  public long timeOfLastImpWrite = 0;
+  public int impWriteCounter = 0;
+  public boolean isWritingImp = false;
+  public void initImpWrite(int _numChannel) {  //numChannel counts from zero
+        timeOfLastImpWrite = millis();
+        isWritingImp = true;
+  }
+  public void writeImpedanceSettings(int _numChannel,char[][] impedanceCheckValues) {  //numChannel counts from zero
+    //after clicking an impedance button, write the new impedance settings for that channel to OpenBCI
+    //after clicking any button, write the new settings for that channel to OpenBCI
+    // verbosePrint("Writing impedance settings for channel " + _numChannel + " to OpenBCI!");
+    //write setting 1, delay 5ms.. write setting 2, delay 5ms, etc.
+    if (millis() - timeOfLastImpWrite >= 50) { //wait 50 milliseconds before sending next character
+      verbosePrint("---");
+      switch (impWriteCounter) {
+        case 0: //start sequence by sending 'z'
+          verbosePrint("z" + " :: " + millis());
+          serial_openBCI.write('z');
+          break;
+        case 1: //send channel number
+          verbosePrint(str(_numChannel+1) + " :: " + millis());
+          if (_numChannel < 8) {
+            serial_openBCI.write((char)('0'+(_numChannel+1)));
+          }
+          if (_numChannel >= 8) {
+            //openBCI.serial_openBCI.write((command_activate_channel_daisy[_numChannel-8]));
+            serial_openBCI.write((command_activate_channel[_numChannel])); //command_activate_channel holds non-daisy and daisy values
+          }
+          break;
+        case 2: 
+        case 3: 
+          verbosePrint(impedanceCheckValues[_numChannel][impWriteCounter-2] + " :: " + millis());
+          serial_openBCI.write(impedanceCheckValues[_numChannel][impWriteCounter-2]);
+          //value for ON/OF
+          break;
+        case 4:
+          verbosePrint("Z" + " :: " + millis());
+          serial_openBCI.write('Z'); // send 'X' to end message sequence
+          break;
+        case 5:
+          verbosePrint("done writing imp settings.");
+          isWritingImp = false;
+          impWriteCounter = -1;
+          break;
+      }
+      timeOfLastImpWrite = millis();
+      impWriteCounter++;
+    }
+  }
+
+ 
 };  
  

--- a/OpenBCI_GUI/OpenBCI_ADS1299.pde
+++ b/OpenBCI_GUI/OpenBCI_ADS1299.pde
@@ -267,9 +267,11 @@ class OpenBCI_ADS1299 {
   //read from the serial port
   int read() {  return read(false); }
   int read(boolean echoChar) {
-    // print("State: " + state);
+    //println("OpenBCI_ADS1299: read(): State: " + state);
     //get the byte
+    if (isRunning) println("OpenBCI_ADS1299: read(): getting byte");
     byte inByte = byte(serial_openBCI.read());
+    if (isRunning) println("OpenBCI_ADS1299: read(): got byte " + int(inByte));
 
     //write the most recent char to the console
     if (echoChar){  //if not in interpret binary (NORMAL) mode

--- a/OpenBCI_GUI/OpenBCI_ADS1299.pde
+++ b/OpenBCI_GUI/OpenBCI_ADS1299.pde
@@ -121,7 +121,7 @@ class OpenBCI_ADS1299 {
       }
     }
 
-    println(" a");
+    println("OpenBCI_ADS1299: a");
 
     dataMode = prefered_datamode;
 
@@ -141,17 +141,17 @@ class OpenBCI_ADS1299 {
       //prevDataPacket.auxValues[i] = 0;
     }
 
-    println(" b");
+    println("OpenBCI_ADS1299: b");
 
     //prepare the serial port  ... close if open
-    println("port is open? ... " + portIsOpen);
+    println("OpenBCI_ADS1299: port is open? ... " + portIsOpen);
     if(portIsOpen == true){
       closeSerialPort();
     }
 
-    println(" i");
+    println("OpenBCI_ADS1299: i");
     openSerialPort(applet, comPort, baud);
-    println(" j");
+    println("OpenBCI_ADS1299: j");
     
     //open file for raw bytes
     //output = createOutput("rawByteDumpFromProcessing.bin");  //for debugging  WEA 2014-01-26
@@ -161,17 +161,17 @@ class OpenBCI_ADS1299 {
   private int openSerialPort(PApplet applet, String comPort, int baud) {
     
     try {
-      println("OpenBCI_ADS1299: attempting to open serial port " + openBCI_portName);
+      println("OpenBCI_ADS1299: openSerialPort: attempting to open serial port " + openBCI_portName);
       serial_openBCI = new Serial(applet,comPort,baud); //open the com port
       serial_openBCI.clear(); // clear anything in the com port's buffer    
       portIsOpen = true;
-      println("port is open (t)? ... " + portIsOpen);
+      println("OpenBCI_ADS1299: openSerialPort: port is open (t)? ... " + portIsOpen);
       changeState(STATE_COMINIT);
       return 0;
     } 
     catch (RuntimeException e){
       if (e.getMessage().contains("<init>")) {
-        System.out.println("port in use, trying again later...");
+        System.out.println("OpenBCI_ADS1299: openSerialPort: port in use, trying again later...");
         portIsOpen = false;
       }
       return 0;
@@ -187,10 +187,10 @@ class OpenBCI_ADS1299 {
   int finalizeCOMINIT() {
     // //wait specified time for COM/serial port to initialize
     // if (state == STATE_COMINIT) {
-    //   // println("Initializing Serial: millis() = " + millis());
+    //   // println("OpenBCI_ADS1299: finalizeCOMINIT: Initializing Serial: millis() = " + millis());
     //   if ((millis() - prevState_millis) > COM_INIT_MSEC) {
     //     //serial_openBCI.write(command_activates + "\n"); println("Processing: OpenBCI_ADS1299: activating filters");
-    //     println("OpenBCI_ADS1299: State = NORMAL");
+    //     println("OpenBCI_ADS1299: finalizeCOMINIT: State = NORMAL");
         changeState(STATE_NORMAL);
     //     // startRunning();
     //   }
@@ -201,17 +201,17 @@ class OpenBCI_ADS1299 {
   int closeSerialPort() {
 
     // if (serial_openBCI != null) {
-    println(" d");
+    println("OpenBCI_ADS1299: closeSerialPort: d");
     portIsOpen = false;
-    println(" e");
+    println("OpenBCI_ADS1299: closeSerialPort: e");
     serial_openBCI.clear();
-    println(" e2");
+    println("OpenBCI_ADS1299: closeSerialPort: e2");
     serial_openBCI.stop();
-    println(" f");
+    println("OpenBCI_ADS1299: closeSerialPort: f");
     serial_openBCI = null;
-    println(" g");
+    println("OpenBCI_ADS1299: closeSerialPort: g");
     state = STATE_NOCOM;
-    println(" h");
+    println("OpenBCI_ADS1299: closeSerialPort: h");
     return 0;
   }
   
@@ -250,7 +250,7 @@ class OpenBCI_ADS1299 {
       serial_openBCI.clear(); // clear anything in the com port's buffer
       // stopDataTransfer();
       openBCI.changeState(STATE_NORMAL);  // make sure it's now interpretting as binary
-      println("writing \'" + command_startBinary + "\' to the serial port...");
+      println("OpenBCI_ADS1299: startDataTransfer: writing \'" + command_startBinary + "\' to the serial port...");
       serial_openBCI.write(command_startBinary);
     }
   }
@@ -259,7 +259,7 @@ class OpenBCI_ADS1299 {
     if (serial_openBCI != null) {
       serial_openBCI.clear(); // clear anything in the com port's buffer
       openBCI.changeState(STATE_STOPPED);  // make sure it's now interpretting as binary
-      println("writing \'" + command_stop + "\' to the serial port...");
+      println("OpenBCI_ADS1299: startDataTransfer: writing \'" + command_stop + "\' to the serial port...");
       serial_openBCI.write(command_stop);// + "\n");
     }
   }
@@ -304,11 +304,11 @@ class OpenBCI_ADS1299 {
         // hardwareSyncStep++;
         prev3chars[2] = '#';
         if(hardwareSyncStep == 3){
-          println("x");
+          println("OpenBCI_ADS1299: read(): x");
           println(defaultChannelSettings);
-          println("y");
+          println("OpenBCI_ADS1299: read(): y");
           gui.cc.loadDefaultChannelSettings();
-          println("z");
+          println("OpenBCI_ADS1299: read(): z");
         }
         readyToSend = true; 
         // println(hardwareSyncStep);
@@ -321,7 +321,7 @@ class OpenBCI_ADS1299 {
       try {
        output.write(inByte);   //for debugging  WEA 2014-01-26
       } catch (IOException e) {
-        System.err.println("OpenBCI_ADS1299: Caught IOException: " + e.getMessage());
+        System.err.println("OpenBCI_ADS1299: read(): Caught IOException: " + e.getMessage());
         //do nothing
       }
     }
@@ -433,14 +433,13 @@ class OpenBCI_ADS1299 {
           flag_copyRawDataToFullData = true;  //time to copy the raw data packet into the full data packet (mainly relevant for 16-chan OpenBCI) 
         } else {
           serialErrorCounter++;
-          println("Actbyte = " + actbyte);
+          println("OpenBCI_ADS1299: interpretBinaryStream: Actbyte = " + actbyte);
           println("OpenBCI_ADS1299: interpretBinaryStream: expecteding end-of-packet byte is missing.  Discarding packet. (" + serialErrorCounter + ")");
         }
         PACKET_readstate=0;  // either way, look for next packet
         break;
       default: 
-          //println("OpenBCI_ADS1299: Unknown byte: " + actbyte + " .  Continuing...");
-          println("OpenBCI_ADS1299: interpretBinaryStream: Unknown byte.  Continuing...");
+          println("OpenBCI_ADS1299: interpretBinaryStream: Unknown byte: " + actbyte + " .  Continuing...");
           PACKET_readstate=0;  // look for next packet
     }
     

--- a/OpenBCI_GUI/OpenBCI_ADS1299.pde
+++ b/OpenBCI_GUI/OpenBCI_ADS1299.pde
@@ -66,6 +66,7 @@ class OpenBCI_ADS1299 {
   
   //here is the serial port for this OpenBCI board
   private Serial serial_openBCI = null; 
+  private boolean portIsOpen = false;
   
   int prefered_datamode = DATAMODE_BIN_WAUX;
   
@@ -159,8 +160,9 @@ class OpenBCI_ADS1299 {
     println("OpenBCI_ADS1299: b");
 
     //prepare the serial port  ... close if open
-    println("OpenBCI_ADS1299: port is open? ... " + portIsOpen);
-    if(portIsOpen == true){
+    //println("OpenBCI_ADS1299: port is open? ... " + portIsOpen);
+    //if(portIsOpen == true) {
+    if (isSerialPortOpen()) {
       closeSerialPort();
     }
 
@@ -186,6 +188,7 @@ class OpenBCI_ADS1299 {
     } 
     catch (RuntimeException e){
       if (e.getMessage().contains("<init>")) {
+        serial_openBCI = null;
         System.out.println("OpenBCI_ADS1299: openSerialPort: port in use, trying again later...");
         portIsOpen = false;
       }
@@ -372,7 +375,13 @@ class OpenBCI_ADS1299 {
     }
   }
   
-  public boolean isSerialPortOpen() { return (serial_openBCI != null); }
+  public boolean isSerialPortOpen() { 
+    if (portIsOpen & (serial_openBCI != null)) {
+      return true;
+    } else {
+      return false;
+    }
+  }
   public boolean isOpenBCISerial(Serial port) {
     if (serial_openBCI == port) {
       return true;

--- a/OpenBCI_GUI/OpenBCI_ADS1299.pde
+++ b/OpenBCI_GUI/OpenBCI_ADS1299.pde
@@ -269,10 +269,8 @@ class OpenBCI_ADS1299 {
   int read(boolean echoChar) {
     //println("OpenBCI_ADS1299: read(): State: " + state);
     //get the byte
-    if (isRunning) println("OpenBCI_ADS1299: read(): getting byte");
     byte inByte = byte(serial_openBCI.read());
-    if (isRunning) println("OpenBCI_ADS1299: read(): got byte " + int(inByte));
-
+    
     //write the most recent char to the console
     if (echoChar){  //if not in interpret binary (NORMAL) mode
       // print(".");
@@ -560,7 +558,7 @@ class OpenBCI_ADS1299 {
     //This function here decides how to join the latest data (rawReceivedDataPacket) into the full dataPacket
     
     if (dataPacket.values.length < 2*rawReceivedDataPacket.values.length) {
-      //simply copy the data
+      //this is an 8 channel board, so simply copy the data
       return rawReceivedDataPacket.copyTo(dataPacket);
     } else {
       //this is 16-channels, so copy the raw data into the correct channels of the new data
@@ -568,7 +566,8 @@ class OpenBCI_ADS1299 {
       int offsetInd_aux = 0;     //this is correct assuming we just recevied a  "board" packet (ie, channels 1-8)
       if (rawReceivedDataPacket.sampleIndex % 2 == 0) { // even data packets are from the daisy board
         offsetInd_values = rawReceivedDataPacket.values.length;  //start copying to the 8th slot
-        offsetInd_aux = rawReceivedDataPacket.auxValues.length;  //start copying to the 3rd slot
+        //offsetInd_aux = rawReceivedDataPacket.auxValues.length;  //start copying to the 3rd slot
+        offsetInd_aux = 0;  
       }
       return rawReceivedDataPacket.copyTo(dataPacket,offsetInd_values,offsetInd_aux);
     }

--- a/OpenBCI_GUI/OpenBCI_ADS1299.pde
+++ b/OpenBCI_GUI/OpenBCI_ADS1299.pde
@@ -67,6 +67,9 @@ class OpenBCI_ADS1299 {
   final static byte BYTE_START = (byte)0xA0;
   final static byte BYTE_END = (byte)0xC0;
   
+  //here is the serial port for this OpenBCI board
+  public Serial serial_openBCI = null; 
+  
   int prefered_datamode = DATAMODE_BIN_WAUX;
   
   int state = STATE_NOCOM;

--- a/OpenBCI_GUI/OpenBCI_GUI.pde
+++ b/OpenBCI_GUI/OpenBCI_GUI.pde
@@ -618,11 +618,21 @@ int getDataIfAvailable(int pointCounter) {
   return pointCounter;
 }
 
+RunningMean avgBitRate = new RunningMean(10);  //10 point running average...at 5 points per second, this should be 2 second running average
+
 void processNewData() {
 
-  byteRate_perSec = (int)(1000.f * ((float)(openBCI_byteCount - prevBytes)) / ((float)(millis() - prevMillis)));
-  prevBytes = openBCI_byteCount; 
-  prevMillis=millis();
+  //compute instantaneous byte rate
+  float inst_byteRate_perSec = (int)(1000.f * ((float)(openBCI_byteCount - prevBytes)) / ((float)(millis() - prevMillis)));
+
+  prevMillis=millis();           //store for next time
+  prevBytes = openBCI_byteCount; //store for next time
+  
+  //compute smoothed byte rate
+  avgBitRate.addValue(inst_byteRate_perSec);
+  byteRate_perSec = (int)avgBitRate.calcMean();
+
+  //prepare to update the data buffers
   float foo_val;
   float prevFFTdata[] = new float[fftBuff[0].specSize()];
   double foo;

--- a/OpenBCI_GUI/OpenBCI_GUI.pde
+++ b/OpenBCI_GUI/OpenBCI_GUI.pde
@@ -253,7 +253,7 @@ int drawLoop_counter = 0;
 //used to init system based on initial settings
 void initSystem(){
 
-  verbosePrint("OpenBCI_GUI: initSystem:-- Init 0 --");
+  verbosePrint("OpenBCI_GUI: initSystem: -- Init 0 --");
   timeOfInit = millis(); //store this for timeout in case init takes too long
 
   //prepare data variables
@@ -364,15 +364,7 @@ void haltSystem(){
 
   if ((eegDataSource == DATASOURCE_NORMAL) || (eegDataSource == DATASOURCE_NORMAL_W_AUX)){
     closeLogFile();  //close log file
-    if (openBCI.serial_openBCI != null){
-      println("Closing any open SD file. Writing 'j' to OpenBCI.");
-      openBCI.serial_openBCI.write("j"); // tell the SD file to close if one is open...
-      delay(100); //make sure 'j' gets sent to the board
-      openBCI.readyToSend = false;
-      openBCI.closeSerialPort();   //disconnect from serial port
-      openBCI.prevState_millis = 0;  //reset OpenBCI_ADS1299 state clock to use as a conditional for timing at the beginnign of systemUpdate()
-      openBCI.hardwareSyncStep = 0; //reset Hardware Sync step to be ready to go again...
-    }
+    openBCI.closeSDandSerialPort();
   }
   systemMode = 0;
 }
@@ -728,7 +720,7 @@ void processNewData() {
 //pre-allocated dataPacketBuff
 void serialEvent(Serial port) {
   //check to see which serial port it is
-  if (port == openBCI.serial_openBCI) {
+  if (openBCI.isOpenBCISerial(port)) {
     // println("OpenBCI_GUI: serialEvent: millis = " + millis());
 
     // boolean echoBytes = !openBCI.isStateNormal(); 
@@ -986,10 +978,7 @@ void mouseReleased() {
 }
 
 void printRegisters(){
-  if (openBCI.serial_openBCI != null) {
-    println("OpenBCI_GUI: printRegisters: Writing ? to OpenBCI...");
-    openBCI.serial_openBCI.write('?');
-  }
+  openBCI.printRegisters();
   // printingRegisters = true;
 }
 

--- a/OpenBCI_GUI/OpenBCI_GUI.pde
+++ b/OpenBCI_GUI/OpenBCI_GUI.pde
@@ -3,7 +3,7 @@
 // GUI for controlling the ADS1299-based OpenBCI
 //
 // Created: Chip Audette, Oct 2013 - May 2014
-// Modified: Conor Russomanno & Joel Murphy, August 2014 - Oct 2014
+// Modified: Conor Russomanno & Joel Murphy, August 2014 - Dec 2014
 //
 // Requires gwoptics graphing library for processing.  Built on V0.5.0
 // http://www.gwoptics.org/processing/gwoptics_p5lib/

--- a/OpenBCI_GUI/OpenBCI_GUI.pde
+++ b/OpenBCI_GUI/OpenBCI_GUI.pde
@@ -820,7 +820,6 @@ void processNewData() {
 //pre-allocated dataPacketBuff
 void serialEvent(Serial port) {
   //check to see which serial port it is
-  if (isRunning) println("OpenBCI_GUI: serialEvent() start.");
   if (port == openBCI.serial_openBCI) {
     // println("SE " + millis());
 
@@ -833,14 +832,9 @@ void serialEvent(Serial port) {
       echoBytes = false;
     }
 
-    // openBCI.read(true);
-    if (isRunning) println("OpenBCI_GUI: serialEvent(): openBCI.read()");
     openBCI.read(echoBytes);
     openBCI_byteCount++;
-    if (isRunning) println("OpenBCI_GUI: serialEvent(): openBCI_byteCount = " + openBCI_byteCount);
     if (openBCI.isNewDataPacketAvailable) {
-      if (isRunning) println("OpenBCI_GUI: serialEvent(): openBCI.isNewDataPacketAvailable = " + openBCI.isNewDataPacketAvailable);
-      
       //copy packet into buffer of data packets
       curDataPacketInd = (curDataPacketInd+1) % dataPacketBuff.length; //this is also used to let the rest of the code that it may be time to do something
       openBCI.copyDataPacketTo(dataPacketBuff[curDataPacketInd]);  //resets isNewDataPacketAvailable to false
@@ -853,9 +847,7 @@ void serialEvent(Serial port) {
       // println("nchan = " + nchan);
       newPacketCounter++;
 
-      if (isRunning) println("OpenBCI_GUI: serialEvent(): writing to file");
       fileoutput.writeRawData_dataPacket(dataPacketBuff[curDataPacketInd],openBCI.scale_fac_uVolts_per_count,openBCI.scale_fac_accel_G_per_count);
-      if (isRunning) println("OpenBCI_GUI: serialEvent(): finished writing to file");
     }
   } 
   else {

--- a/OpenBCI_GUI/OpenBCI_GUI.pde
+++ b/OpenBCI_GUI/OpenBCI_GUI.pde
@@ -42,7 +42,7 @@ public int eegDataSource = -1; //default to none of the options
 OpenBCI_ADS1299 openBCI = new OpenBCI_ADS1299(); //dummy creation to get access to constants, create real one later
 String openBCI_portName = "N/A";  //starts as N/A but is selected from control panel to match your OpenBCI USB Dongle's serial/COM
 int openBCI_baud = 115200; //baud rate from the Arduino
-boolean portIsOpen = false; //serial port open or closed(?)
+//boolean portIsOpen = false; //serial port open or closed(?)
 
 //here are variables that are used if loading input data from a CSV text file...double slash ("\\") is necessary to make a single slash
 String playbackData_fname = "N/A"; //only used if loading input data from a file

--- a/OpenBCI_GUI/OpenBCI_GUI.pde
+++ b/OpenBCI_GUI/OpenBCI_GUI.pde
@@ -42,6 +42,8 @@ public int eegDataSource = -1; //default to none of the options
 OpenBCI_ADS1299 openBCI = new OpenBCI_ADS1299(); //dummy creation to get access to constants, create real one later
 String openBCI_portName = "N/A";  //starts as N/A but is selected from control panel to match your OpenBCI USB Dongle's serial/COM
 int openBCI_baud = 115200; //baud rate from the Arduino
+boolean portIsOpen = false; //serial port open or closed(?)
+Serial serial_openBCI = null;
 
 
 //here are variables that are used if loading input data from a CSV text file...double slash ("\\") is necessary to make a single slash
@@ -91,16 +93,22 @@ float yLittleBuff[] = new float[nPointsPerUpdate];
 float yLittleBuff_uV[][] = new float[nchan][nPointsPerUpdate]; //small buffer used to send data to the filters
 float data_elec_imp_ohm[];
 
-//fft constants
-int Nfft = 256; //set resolution of the FFT.  Use N=256 for normal, N=512 for MU waves
-FFT fftBuff[] = new FFT[nchan];   //from the minim library
-float[] smoothFac = new float[]{0.75, 0.9, 0.95, 0.98, 0.0, 0.5};
-int smoothFac_ind = 0;    //initial index into the smoothFac array
+//variables for writing EEG data out to a file
+OutputFile_rawtxt fileoutput;
+String output_fname;
+String fileName = "N/A";
 
 //create objects that'll do the EEG signal processing
 EEG_Processing eegProcessing;
 EEG_Processing_User eegProcessing_user;
 
+
+
+//fft constants
+int Nfft = 256; //set resolution of the FFT.  Use N=256 for normal, N=512 for MU waves
+FFT fftBuff[] = new FFT[nchan];   //from the minim library
+float[] smoothFac = new float[]{0.75, 0.9, 0.95, 0.98, 0.0, 0.5};
+int smoothFac_ind = 0;    //initial index into the smoothFac array
 
 //plotting constants
 color bgColor = color(1, 18, 41);
@@ -124,15 +132,6 @@ int inByte = -1;    // Incoming serial data
 
 //Help Widget initiation
 HelpWidget helpWidget;
-
-//file writing variables
-OutputFile_rawtxt fileoutput;
-String output_fname;
-String fileName = "N/A";
-
-//serial port open or closed(?)
-boolean portIsOpen = false;
-Serial serial_openBCI = null;
 
 //for screen resizing
 boolean screenHasBeenResized = false;

--- a/OpenBCI_GUI/OpenBCI_GUI.pde
+++ b/OpenBCI_GUI/OpenBCI_GUI.pde
@@ -139,8 +139,6 @@ float timeOfLastScreenResize = 0;
 float timeOfGUIreinitialize = 0;
 int reinitializeGUIdelay = 125;
 
-
-
 //set window size
 int win_x = 1024;  //window width
 int win_y = 768; //window height
@@ -195,7 +193,12 @@ void setup() {
 
   controlPanelCollapser.setIsActive(true);
   controlPanelCollapser.makeDropdownButton(true);
-  controlPanel = new ControlPanel(this); 
+  
+  //from the user's perspective, the program hangs out on the ControlPanel until the user presses "Start System".
+  controlPanel = new ControlPanel(this);  
+  //The effect of "Start System" is that initSystem() gets called, which starts up the conneciton to the OpenBCI
+  //hardware (via the "updateSyncState()" process) as well as initializing the rest of the GUI elements.  
+  //Once the hardware is synchronized, the main GUI is drawn and the user switches over to the main GUI.
 
   logo = loadImage("logo2.png");
 
@@ -212,7 +215,7 @@ int prevMillis=millis();
 int byteRate_perSec = 0;
 int drawLoop_counter = 0;
 
-//used to init system based on initial settings
+//used to init system based on initial settings...Called from the "Start System" button in the GUI's ControlPanel
 void initSystem(){
 
   verbosePrint("OpenBCI_GUI: initSystem: -- Init 0 --");

--- a/OpenBCI_GUI/OpenBCI_GUI.pde
+++ b/OpenBCI_GUI/OpenBCI_GUI.pde
@@ -820,6 +820,7 @@ void processNewData() {
 //pre-allocated dataPacketBuff
 void serialEvent(Serial port) {
   //check to see which serial port it is
+  if (isRunning) println("OpenBCI_GUI: serialEvent() start.");
   if (port == openBCI.serial_openBCI) {
     // println("SE " + millis());
 
@@ -833,9 +834,13 @@ void serialEvent(Serial port) {
     }
 
     // openBCI.read(true);
+    if (isRunning) println("OpenBCI_GUI: serialEvent(): openBCI.read()");
     openBCI.read(echoBytes);
     openBCI_byteCount++;
+    if (isRunning) println("OpenBCI_GUI: serialEvent(): openBCI_byteCount = " + openBCI_byteCount);
     if (openBCI.isNewDataPacketAvailable) {
+      if (isRunning) println("OpenBCI_GUI: serialEvent(): openBCI.isNewDataPacketAvailable = " + openBCI.isNewDataPacketAvailable);
+      
       //copy packet into buffer of data packets
       curDataPacketInd = (curDataPacketInd+1) % dataPacketBuff.length; //this is also used to let the rest of the code that it may be time to do something
       openBCI.copyDataPacketTo(dataPacketBuff[curDataPacketInd]);  //resets isNewDataPacketAvailable to false
@@ -848,10 +853,13 @@ void serialEvent(Serial port) {
       // println("nchan = " + nchan);
       newPacketCounter++;
 
+      if (isRunning) println("OpenBCI_GUI: serialEvent(): writing to file");
       fileoutput.writeRawData_dataPacket(dataPacketBuff[curDataPacketInd],openBCI.scale_fac_uVolts_per_count,openBCI.scale_fac_accel_G_per_count);
+      if (isRunning) println("OpenBCI_GUI: serialEvent(): finished writing to file");
     }
   } 
   else {
+    println("OpenBCI_GUI: serialEvent: received serial data NOT from OpenBCI.");
     inByte = port.read();
   }
 }

--- a/OpenBCI_GUI/ParseKey.pde
+++ b/OpenBCI_GUI/ParseKey.pde
@@ -183,7 +183,7 @@ void parseKey(char val) {
     case 'd':
       verbosePrint("Updating GUI's channel settings to default...");
       gui.cc.loadDefaultChannelSettings();
-      serial_openBCI.write('d');
+      openBCI.serial_openBCI.write('d');
       break;
       
     // //change the state of the impedance measurements...activate the N-channels
@@ -248,7 +248,7 @@ void parseKey(char val) {
     default:
      println("OpenBCI_GUI: '" + key + "' Pressed...sending to OpenBCI...");
      // if (openBCI.serial_openBCI != null) openBCI.serial_openBCI.write(key);//send the value as ascii with a newline character
-     if (serial_openBCI != null) serial_openBCI.write(key);//send the value as ascii with a newline character
+     if (openBCI.serial_openBCI != null) openBCI.serial_openBCI.write(key);//send the value as ascii with a newline character
     
      break;
   }

--- a/OpenBCI_GUI/ParseKey.pde
+++ b/OpenBCI_GUI/ParseKey.pde
@@ -183,7 +183,8 @@ void parseKey(char val) {
     case 'd':
       verbosePrint("Updating GUI's channel settings to default...");
       gui.cc.loadDefaultChannelSettings();
-      openBCI.serial_openBCI.write('d');
+      //openBCI.serial_openBCI.write('d');
+      openBCI.configureAllChannelsToDefault();
       break;
       
     // //change the state of the impedance measurements...activate the N-channels
@@ -248,7 +249,8 @@ void parseKey(char val) {
     default:
      println("OpenBCI_GUI: '" + key + "' Pressed...sending to OpenBCI...");
      // if (openBCI.serial_openBCI != null) openBCI.serial_openBCI.write(key);//send the value as ascii with a newline character
-     if (openBCI.serial_openBCI != null) openBCI.serial_openBCI.write(key);//send the value as ascii with a newline character
+     //if (openBCI.serial_openBCI != null) openBCI.serial_openBCI.write(key);//send the value as ascii with a newline character
+     openBCI.sendChar(key);
     
      break;
   }

--- a/OpenBCI_GUI/Playground.pde
+++ b/OpenBCI_GUI/Playground.pde
@@ -78,7 +78,7 @@ class Playground {
 	}
 
 	boolean isMouseInButton(){
-		verbosePrint("attempting");
+		verbosePrint("Playground: isMouseInButton: attempting");
 		if(mouseX >= collapser.but_x && mouseX <= collapser.but_x+collapser.but_dx && mouseY >= collapser.but_y && mouseY <= collapser.but_y + collapser.but_dy){
 			return true;
 		} else{

--- a/OpenBCI_GUI/Playground.pde
+++ b/OpenBCI_GUI/Playground.pde
@@ -9,119 +9,114 @@
 
 class Playground {
 
-	//button for opening and closing
-	float x, y, w, h;
-	color boxBG;
-	color strokeColor;
-	float topMargin, bottomMargin;
+  //button for opening and closing
+  float x, y, w, h;
+  color boxBG;
+  color strokeColor;
+  float topMargin, bottomMargin;
 
-	boolean isOpen;
-	boolean collapsing;
+  boolean isOpen;
+  boolean collapsing;
 
-	Button collapser;
+  Button collapser;
 
-	Playground(int _topMargin){
+  Playground(int _topMargin) {
 
-		topMargin = _topMargin;
-		bottomMargin = helpWidget.h;
+    topMargin = _topMargin;
+    bottomMargin = helpWidget.h;
 
-		isOpen = false;
-		collapsing = true;
+    isOpen = false;
+    collapsing = true;
 
-		boxBG = color(255);
-		strokeColor = color(138,146,153);
-		collapser = new Button(0, 0, 20, 60, "<", 14);
+    boxBG = color(255);
+    strokeColor = color(138, 146, 153);
+    collapser = new Button(0, 0, 20, 60, "<", 14);
 
-		x = width;
-		y = topMargin;
-		w = 0;
-		h = height - (topMargin+bottomMargin);
+    x = width;
+    y = topMargin;
+    w = 0;
+    h = height - (topMargin+bottomMargin);
+  }
 
-	}
+  public void update() {
+    // verbosePrint("uh huh");
+    if (collapsing) {
+      collapse();
+    } else {
+      expand();
+    }
 
-	public void update(){
-		// verbosePrint("uh huh");
-		if(collapsing){
-			collapse();
-		} else{
-			expand();
-		}
+    if (x > width) {
+      x = width;
+    }
+  }
 
-		if(x > width){
-			x = width;
-		}
+  public void draw() {
+    // verbosePrint("yeaaa");
+    pushStyle();
+    fill(boxBG);
+    stroke(strokeColor);
+    rect(width - w, topMargin, w, height - (topMargin + bottomMargin));
+    textFont(f1);
+    textAlign(LEFT, TOP);
+    fill(bgColor);
+    text("Developer Playground", x + 10, y + 10);
+    fill(255, 0, 0);
+    collapser.draw(int(x - collapser.but_dx), int(topMargin + (h-collapser.but_dy)/2));
+    popStyle();
+  }
 
-	}
+  boolean isMouseHere() {
+    if (mouseX >= x && mouseX <= width && mouseY >= y && mouseY <= height - bottomMargin) {
+      return true;
+    } else {
+      return false;
+    }
+  }
 
-	public void draw(){
-		// verbosePrint("yeaaa");
-		pushStyle();
-			fill(boxBG);
-			stroke(strokeColor);
-			rect(width - w, topMargin, w, height - (topMargin + bottomMargin));
-			textFont(f1);
-			textAlign(LEFT, TOP);
-			fill(bgColor);
-			text("Developer Playground", x + 10, y + 10);
-			fill(255,0,0);
-			collapser.draw(int(x - collapser.but_dx), int(topMargin + (h-collapser.but_dy)/2));
-		popStyle();
+  boolean isMouseInButton() {
+    verbosePrint("Playground: isMouseInButton: attempting");
+    if (mouseX >= collapser.but_x && mouseX <= collapser.but_x+collapser.but_dx && mouseY >= collapser.but_y && mouseY <= collapser.but_y + collapser.but_dy) {
+      return true;
+    } else {
+      return false;
+    }
+  }
 
-	}
+  public void toggleWindow() {
+    if (isOpen) {//if open
+      verbosePrint("close");
+      collapsing = true;//collapsing = true;
+      isOpen = false;
+      collapser.but_txt = "<";
+    } else {//if closed
+      verbosePrint("open");
+      collapsing = false;//expanding = true;
+      isOpen = true;
+      collapser.but_txt = ">";
+    }
+  }
 
-	boolean isMouseHere(){
-		if(mouseX >= x && mouseX <= width && mouseY >= y && mouseY <= height - bottomMargin){
-			return true;
-		} else {
-			return false;
-		}
-	}
+  public void mousePressed() {
+    verbosePrint("Playground >> mousePressed()");
+  }
 
-	boolean isMouseInButton(){
-		verbosePrint("Playground: isMouseInButton: attempting");
-		if(mouseX >= collapser.but_x && mouseX <= collapser.but_x+collapser.but_dx && mouseY >= collapser.but_y && mouseY <= collapser.but_y + collapser.but_dy){
-			return true;
-		} else{
-			return false;
-		}
-	}
+  public void mouseReleased() {
+    verbosePrint("Playground >> mouseReleased()");
+  }
 
-	public void toggleWindow(){
-		if(isOpen){//if open
-			verbosePrint("close");
-			collapsing = true;//collapsing = true;
-			isOpen = false;
-			collapser.but_txt = "<";
-		} else {//if closed
-			verbosePrint("open");
-			collapsing = false;//expanding = true;
-			isOpen = true;
-			collapser.but_txt = ">";
-		}
-	}
+  public void expand() {
+    if (w <= width/3) {
+      w = w + 50;
+      x = width - w;
+    }
+  }
 
-	public void mousePressed(){
-		verbosePrint("Playground >> mousePressed()");
-	}
-
-	public void mouseReleased(){
-		verbosePrint("Playground >> mouseReleased()");
-	}
-
-	public void expand(){
-		if(w <= width/3){
-			w = w + 50;
-			x = width - w;
-		}
-	}
-
-	public void collapse(){
-		if(w >= 0){
-			w = w - 50;
-			x = width - w;
-		}
-	}
-
-
-
+  public void collapse() {
+    if (w >= 0) {
+      w = w - 50;
+      x = width - w;
+    }
+  }
 };
+

--- a/OpenBCI_GUI/SDConverter.pde
+++ b/OpenBCI_GUI/SDConverter.pde
@@ -19,81 +19,81 @@ String logFileName;
 long thisTime;
 long thatTime;
 
-public void convertSDFile(){
-	println("");
-	try {
-	 	dataLine = dataReader.readLine();
-	} catch (IOException e) {
-	 	e.printStackTrace();
-	 	dataLine = null;
-	}
+public void convertSDFile() {
+  println("");
+  try {
+    dataLine = dataReader.readLine();
+  } 
+  catch (IOException e) {
+    e.printStackTrace();
+    dataLine = null;
+  }
 
-	if (dataLine == null) {
-		// Stop reading because of an error or file is empty
-		thisTime = millis() - thatTime;
-		controlPanel.convertingSD = false;
-		println("nothing left in file"); 
-		println("SD file conversion took "+thisTime+" mS");
-		dataWriter.flush();
-		dataWriter.close();
-	} else{
-		//        println(dataLine);
-		String[] hexNums = splitTokens(dataLine,",");
+  if (dataLine == null) {
+    // Stop reading because of an error or file is empty
+    thisTime = millis() - thatTime;
+    controlPanel.convertingSD = false;
+    println("nothing left in file"); 
+    println("SD file conversion took "+thisTime+" mS");
+    dataWriter.flush();
+    dataWriter.close();
+  } else {
+    //        println(dataLine);
+    String[] hexNums = splitTokens(dataLine, ",");
 
-		if(hexNums[0].charAt(0) == '%'){
-			//          println(dataLine);
-			dataWriter.println(dataLine);
-			println(dataLine);
-		}
-		else{
-			for(int i=0; i<hexNums.length; i++){
-				h = hexNums[i];
-				if(i > 0){
-				    if(h.charAt(0) > '7'){  // if the number is negative 
-				    	h = "FF" + hexNums[i];   // keep it negative
-				    } else{                  // if the number is positive
-				    	h = "00" + hexNums[i];   // keep it positive
-				    }
-				    if(i > 8){ // accelerometer data needs another byte
-				    	if(h.charAt(0) == 'F'){
-				        	h = "FF" + h;
-				      	}else{
-				        	h = "00" + h;
-				      	}
-				    }
-			  	}
-			  // println(h); // use for debugging
-			    if (h.length()%2 == 0){  // make sure this is a real number
-					intData[i] = unhex(h);
-			    } else{
-			    	intData[i] = 0;          
-			    }
-			  
-				//if not first column(sample #) or columns 9-11 (accelerometer), convert to uV
-				if(i>=1 && i<=8){
-					intData[i] *= openBCI.scale_fac_uVolts_per_count;
-				}
-			  
-				//print the current channel value
-				dataWriter.print(intData[i]);
-				if(i < hexNums.length-1){
-					//print "," separator
-			    	dataWriter.print(",");
-				}
-			}
-			//println();
-			dataWriter.println();
-		} 
-	}   
+    if (hexNums[0].charAt(0) == '%') {
+      //          println(dataLine);
+      dataWriter.println(dataLine);
+      println(dataLine);
+    } else {
+      for (int i=0; i<hexNums.length; i++) {
+        h = hexNums[i];
+        if (i > 0) {
+          if (h.charAt(0) > '7') {  // if the number is negative 
+            h = "FF" + hexNums[i];   // keep it negative
+          } else {                  // if the number is positive
+            h = "00" + hexNums[i];   // keep it positive
+          }
+          if (i > 8) { // accelerometer data needs another byte
+            if (h.charAt(0) == 'F') {
+              h = "FF" + h;
+            } else {
+              h = "00" + h;
+            }
+          }
+        }
+        // println(h); // use for debugging
+        if (h.length()%2 == 0) {  // make sure this is a real number
+          intData[i] = unhex(h);
+        } else {
+          intData[i] = 0;
+        }
+
+        //if not first column(sample #) or columns 9-11 (accelerometer), convert to uV
+        if (i>=1 && i<=8) {
+          intData[i] *= openBCI.scale_fac_uVolts_per_count;
+        }
+
+        //print the current channel value
+        dataWriter.print(intData[i]);
+        if (i < hexNums.length-1) {
+          //print "," separator
+          dataWriter.print(",");
+        }
+      }
+      //println();
+      dataWriter.println();
+    }
+  }
 }
 
-void createPlaybackFileFromSD(){
-   logFileName = "data/EEG_Data/SDconverted-"+getDateString()+".txt";
-   dataWriter = createWriter(logFileName);
-   dataWriter.println("%OBCI Data Log - " + getDateString());
+void createPlaybackFileFromSD() {
+  logFileName = "data/EEG_Data/SDconverted-"+getDateString()+".txt";
+  dataWriter = createWriter(logFileName);
+  dataWriter.println("%OBCI Data Log - " + getDateString());
 }
 
-void sdFileSelected(File selection){
+void sdFileSelected(File selection) {
   if (selection == null) {
     println("Window was closed or the user hit cancel.");
   } else {
@@ -104,3 +104,4 @@ void sdFileSelected(File selection){
     thatTime = millis();
   }
 }
+

--- a/OpenBCI_GUI/SDConverter.pde
+++ b/OpenBCI_GUI/SDConverter.pde
@@ -71,7 +71,7 @@ public void convertSDFile() {
 
         //if not first column(sample #) or columns 9-11 (accelerometer), convert to uV
         if (i>=1 && i<=8) {
-          intData[i] *= openBCI.scale_fac_uVolts_per_count;
+          intData[i] *= openBCI.get_scale_fac_uVolts_per_count();
         }
 
         //print the current channel value

--- a/OpenBCI_GUI/dataTypes.pde
+++ b/OpenBCI_GUI/dataTypes.pde
@@ -32,16 +32,20 @@ class DataPacket_ADS1299 {
     println();
     return 0;
   }
-  int copyTo(DataPacket_ADS1299 target) {
+  
+  int copyTo(DataPacket_ADS1299 target) { return copyTo(target, 0, 0); }
+  int copyTo(DataPacket_ADS1299 target, int target_startInd_values, int target_startInd_aux) {
     target.sampleIndex = sampleIndex;
-    //int nvalues = min(values.length, target.values.length); //handles case when nchan < OpenBCI_nchannels
+    return copyValuesAndAuxTo(target, target_startInd_values, target_startInd_aux);
+  }
+  int copyValuesAndAuxTo(DataPacket_ADS1299 target, int target_startInd_values, int target_startInd_aux) {
     int nvalues = values.length;
     for (int i=0; i < nvalues; i++) {
-      target.values[i] = values[i];
+      target.values[target_startInd_values + i] = values[i];
     }
     nvalues = auxValues.length;
     for (int i=0; i < nvalues; i++) {
-      target.auxValues[i] = auxValues[i];
+      target.auxValues[target_startInd_aux + i] = auxValues[i];
     }
     return 0;
   }

--- a/OpenBCI_GUI/dataTypes.pde
+++ b/OpenBCI_GUI/dataTypes.pde
@@ -3,7 +3,7 @@
 //
 // This file contains classes that are helfpul in some way.
 //
-// Created: Chip Audette, Oct 2013
+// Created: Chip Audette, Oct 2013 - Dec 2014
 //
 /////////////////////////////////////
 

--- a/OpenBCI_GUI/math.pde
+++ b/OpenBCI_GUI/math.pde
@@ -148,4 +148,19 @@ void rereferenceTheMontage(float[][] data) {
   }
 }
   
+class RunningMean {
+  private float[] values;
+  private int cur_ind = 0;
+  RunningMean(int N) {
+    values = new float[N];
+    cur_ind = 0;
+  }
+  public void addValue(float val) {
+    values[cur_ind] = val;
+    cur_ind = (cur_ind + 1) % values.length;
+  }
+  public float calcMean() {
+    return mean(values);
+  }
+};
 


### PR DESCRIPTION
My goal was to encapsulate all interaction with the OpenBCI hardware so that it is occurring only through the OpenBCI_ADS1299 class.  By doing this, I can then take the next step, which is to allow our one GUI to service two (or more) OpenBCI systems at the same time.

The previous GUI code assumed that there was only one piece of OpenBCI hardware (which was communicated to via one single Serial connection).  If there will be more than OpenBCI hardware, there will be more than one Serial.  As a result, the GUI code that drops commands directly onto the serial port will fail to communicate to ALL of the OpenBCI boards.

To fix this issue, and to follow better programming practices, I edited all of the references (that I could find) to the OpenBCI serial (and its other data members) so that all of the functionality was encapsulated within the OpenBCI_ADS1299 class.  The rest of the GUI interacts with the hardware through this class via the class' methods (functions).  The GUI no longer communicates with the hardware directly.

Later, when we want to support multiple OpenBCI boards, we can extend the OpenBCI_ADS1299 class (or create a super-class) such that it has the same interfaces (the same method calls), which means that no other changes to the GUI code will be necessary.  That's the goal, at least.