### PR TITLE
Set trace renderer to JAVA2D

### DIFF
--- a/OpenBCI_GUI/Gui_Manager.pde
+++ b/OpenBCI_GUI/Gui_Manager.pde
@@ -648,12 +648,14 @@ class Gui_Manager {
   public void initDataTraces(float[] dataBuffX,float[][] dataBuffY,FFT[] fftBuff,float[] dataBuffY_std, DataStatus[] is_railed, float[] dataBuffY_polarity) {      
     //initialize the time-domain montage-plot traces
     montageTrace = new ScatterTrace();
+    montageTrace.setRenderer(PApplet.JAVA2D);
     montage_yoffsets = new float[nchan];
     initializeMontageTraces(dataBuffX,dataBuffY);
     montageTrace.set_isRailed(is_railed);
   
     //initialize the FFT traces
     fftTrace = new ScatterTrace_FFT(fftBuff); //can't put this here...must be in setup()
+    fftTrace.setRenderer(PApplet.JAVA2D);
     fftYOffset = new float[nchan];
     initializeFFTTraces(fftTrace,fftBuff,fftYOffset,gFFT);
     


### PR DESCRIPTION
I'm curious if this causes a performance hit for anybody.

Locally, my traces were completely blank until I made this change, which changes the renderer to JAVA2D.