### PR TITLE
Fix splitLineCSV and broken CSV export in non US culture

### DIFF
--- a/OpenBCI_GUI/dataFiles.pde
+++ b/OpenBCI_GUI/dataFiles.pde
@@ -80,7 +80,7 @@ public class OutputFile_rawtxt {
     int nVal = values.length;
     for (int Ival = 0; Ival < nVal; Ival++) {
       output.print(", ");
-      output.print(String.format("%.2f", scale_fac * float(values[Ival])));
+      output.print(String.format(Locale.US, "%.2f", scale_fac * float(values[Ival])));
     }
   }
 
@@ -139,11 +139,11 @@ class Table_CSV extends Table {
           setRowCount(row << 1);
         }
         if (row == 0 && header) {
-          setColumnTitles(tsv ? PApplet.split(line, '\t') : splitLineCSV(line));
+          setColumnTitles(tsv ? PApplet.split(line, '\t') : splitLineCSV(line, reader));
           header = false;
         } 
         else {
-          setRow(row, tsv ? PApplet.split(line, '\t') : splitLineCSV(line));
+          setRow(row, tsv ? PApplet.split(line, '\t') : splitLineCSV(line, reader));
           row++;
         }
 


### PR DESCRIPTION
Fixes compilation error splitLineCSV, missing argument. Write float using Locale.US to ensure consistent export in cultures which use a ',' as decimal separator. Otherwise you'd get double comma, very difficult to parse: 0,00, 0,00, 0,00...