### PR TITLE
Append recording/playback time to screenshot

### DIFF
--- a/OpenBCI_GUI/ParseKey.pde
+++ b/OpenBCI_GUI/ParseKey.pde
@@ -372,7 +372,7 @@ void saveScreenshot() {
       recordingTime = "@" + (int)((float)fileoutput.getRowsWritten()/openBCI.get_fs_Hz()) + "s";
       break;
     case DATASOURCE_PLAYBACKFILE:
-      recordingTime = "@" + (int)((float)playbackData_table.getRowCount()/openBCI.get_fs_Hz()) + "s";
+      recordingTime = "@" + (int)((float)currentTableRowIndex/openBCI.get_fs_Hz()) + "s";
       break;
   }
   String picfname = "OpenBCI-" + getDateString() + recordingTime + ".png";

--- a/OpenBCI_GUI/ParseKey.pde
+++ b/OpenBCI_GUI/ParseKey.pde
@@ -249,10 +249,8 @@ void parseKey(char val) {
 
       
     case 'm':
-     String picfname = "OpenBCI-" + getDateString() + ".jpg";
-     println("OpenBCI_GUI: 'm' was pressed...taking screenshot:" + picfname);
-     saveFrame("./SavedData/" + picfname);    // take a shot of that!
-     break;
+      saveScreenshot();
+      break;
 
     default:
      println("OpenBCI_GUI: '" + key + "' Pressed...sending to OpenBCI...");
@@ -364,4 +362,20 @@ void parseKeycode(int val) {
       println("OpenBCI_GUI: parseKeycode(" + val + "): value is not known.  Ignoring...");
       break;
   }
+}
+
+void saveScreenshot() {
+  String recordingTime = "";
+  switch (eegDataSource) {
+    case DATASOURCE_NORMAL: 
+    case DATASOURCE_NORMAL_W_AUX:
+      recordingTime = "@" + (int)((float)fileoutput.getRowsWritten()/openBCI.get_fs_Hz()) + "s";
+      break;
+    case DATASOURCE_PLAYBACKFILE:
+      recordingTime = "@" + (int)((float)playbackData_table.getRowCount()/openBCI.get_fs_Hz()) + "s";
+      break;
+  }
+  String picfname = "OpenBCI-" + getDateString() + recordingTime + ".png";
+  println("OpenBCI_GUI: 'm' was pressed...taking screenshot:" + picfname);
+  saveFrame("./SavedData/" + picfname);    // take a shot of that!
 }


### PR DESCRIPTION
Save screenshot as png instead of jpg and append recording/playback time to file name for later reference. png is about half the file size and eliminates jpg artefacts. 